### PR TITLE
Encoding issue w/ non utf8 messages on log files

### DIFF
--- a/mtools/util/logline.py
+++ b/mtools/util/logline.py
@@ -434,8 +434,7 @@ class LogLine(object):
     def to_json(self, labels=None):
         """ converts LogLine object to valid JSON. """
         output = self.to_dict(labels)
-        decoded = output.decode('utf8','ignore')
-        return json.dumps(decoded, cls=DateTimeEncoder)
+        return json.dumps(output, cls=DateTimeEncoder, ensure_ascii=False)
 
 
 


### PR DESCRIPTION
The mlogvis was breaking due to some text which was not on UTF-8. 
By not forcing the json.dumps to use ASCII it solves the problem. 

This was a quick fix that I need to do at a client. 
I'll be adding a complete unittest latter 

N.
