### PR TITLE
Remove numpy import from query_section.py

### DIFF
--- a/mtools/mloginfo/sections/query_section.py
+++ b/mtools/mloginfo/sections/query_section.py
@@ -7,7 +7,6 @@ from mtools.util import OrderedDict
 
 from operator import itemgetter
 
-import numpy as np
 
 class QuerySection(BaseSection):
     """ 


### PR DESCRIPTION
Allows `mloginfo --queries` to be run without numpy installed
