### PR TITLE
Fix #220: Add 'mloginfo threads' command to split threads into separate files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Changes to mtools
 #### version 1.1.6dev
 
   * mlogfilter: `--thread` now also matches "connection accepted" lines for that connection (#218, #219)
+  * mloginfo: threads command (#220)
 
 
 #### version 1.1.5

--- a/mtools/mloginfo/mloginfo.py
+++ b/mtools/mloginfo/mloginfo.py
@@ -2,29 +2,45 @@
 
 from mtools.util.logfile import LogFile
 from mtools.util.logevent import LogEvent
-from mtools.util.cmdlinetool import LogFileTool
+from mtools.util.cmdlinetool import BaseCmdLineTool, InputSourceAction
 
+import sys
 import inspect
+import argparse
 import mtools.mloginfo.sections as sections
 
 
 
-class MLogInfoTool(LogFileTool):
+class MLogInfoTool(BaseCmdLineTool):
 
     def __init__(self):
         """ Constructor: add description to argparser. """
-        LogFileTool.__init__(self, multiple_logfiles=True, stdin_allowed=False)
-
-        self.argparser.description = 'Extracts general information from logfile and prints it to stdout.'
-        self.argparser.add_argument('--verbose', action='store_true', help='show more verbose output (depends on info section)')
-        self.argparser_sectiongroup = self.argparser.add_argument_group('info sections', 'Below commands activate additional info sections for the log file.')
+        BaseCmdLineTool.__init__(self)
 
         # add all filter classes from the filters module
-        self.sections = [c[1](self) for c in inspect.getmembers(sections, inspect.isclass)]
+        self.sections = dict( [ (c[1].name, c[1](self)) for c in inspect.getmembers(sections, inspect.isclass) ] )
+
+        # initialize arpparser
+        self.argparser.description = 'Extracts general information from logfile and prints it to stdout.'
+        self.argparser.add_argument('--verbose', action='store_true', help='show more verbose output (depends on info section)')
+        
+        # for backwards compatibility, if only a logfile is specified without a command, still print out the basic info
+        # only add command subparsers if there are at least 2 additional arguments (command, logfile) or if --help is invoked
+        if len(sys.argv) != 2 or sys.argv[1] in self.sections.keys() + ['--help', '--version']:
+            # create command sub-parsers
+            subparsers = self.argparser.add_subparsers(title='commands', dest='command')
+
+            for section in self.sections.values():
+                subparser = subparsers.add_parser(section.name, help=section.description, description=section.description)
+                section._add_subparser_arguments(subparser)
+
+        # add logfile action manually at the end
+        self.argparser.add_argument('logfile', action='store', type=InputSourceAction(), nargs='+', help='logfile(s) to parse')
+
 
     def run(self, arguments=None):
         """ Print out useful information about the log file. """
-        LogFileTool.run(self, arguments)
+        BaseCmdLineTool.run(self, arguments)
 
         for i, self.logfile in enumerate(self.args['logfile']):
             if i > 0:
@@ -56,12 +72,12 @@ class MLogInfoTool(LogFileTool):
             print "    version: %s" % version,
             print
 
-            # now run all sections
-            for section in self.sections:
-                if section.active:
-                    print
-                    print section.name.upper()
-                    section.run()
+            # now run requested section
+            if 'command' in self.args:
+                section = self.sections[ self.args['command'] ]
+                print
+                print section.name.upper()
+                section.run()
 
 
 if __name__ == '__main__':

--- a/mtools/mloginfo/sections/__init__.py
+++ b/mtools/mloginfo/sections/__init__.py
@@ -2,3 +2,4 @@ from restart_section import RestartSection
 from distinct_section import DistinctSection
 from connection_section import ConnectionSection
 from query_section import QuerySection
+from threads_section import ThreadsSection

--- a/mtools/mloginfo/sections/base_section.py
+++ b/mtools/mloginfo/sections/base_section.py
@@ -6,7 +6,8 @@ class BaseSection(object):
 
     filterArgs = []
     name = 'base'
-    active = False
+    description = 'description of this section'
+    
 
     def __init__(self, mloginfo):
         """ constructor. save command line arguments and set active to False
@@ -14,8 +15,13 @@ class BaseSection(object):
         """
         # mloginfo object, use it to get access to argparser and other class variables
         self.mloginfo = mloginfo
+        
+    
+    def _add_subparser_arguments(self, subparser):
+        """ add additional subparser arguments in this method if required. """
+        pass
 
-
+    
     def run(self):
         pass
 

--- a/mtools/mloginfo/sections/connection_section.py
+++ b/mtools/mloginfo/sections/connection_section.py
@@ -10,18 +10,7 @@ class ConnectionSection(BaseSection):
     """
     
     name = "connections"
-
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --restarts flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--connections', action='store_true', help='outputs information about opened and closed connections')
-
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['connections']
+    description = "information about opened and closed connections"
 
 
     def run(self):

--- a/mtools/mloginfo/sections/distinct_section.py
+++ b/mtools/mloginfo/sections/distinct_section.py
@@ -13,19 +13,9 @@ class DistinctSection(BaseSection):
     """
     
     name = "distinct"
+    description = 'distinct list of all log line by message type'
+
     log2code = Log2CodeConverter()
-
-
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --restarts flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--distinct', action='store_true', help='outputs distinct list of all log line by message type (slow)')
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['distinct']
 
 
     def run(self):

--- a/mtools/mloginfo/sections/query_section.py
+++ b/mtools/mloginfo/sections/query_section.py
@@ -14,18 +14,12 @@ class QuerySection(BaseSection):
     """
     
     name = "queries"
+    description = 'statistics on query shapes per namespace'
 
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --queries flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--queries', action='store_true', help='outputs statistics about query patterns')
-        self.mloginfo.argparser_sectiongroup.add_argument('--sort', action='store', default='sum', choices=['namespace', 'pattern', 'count', 'min', 'max', 'mean', '95%', 'sum'])
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['queries']
+    
+    def _add_subparser_arguments(self, subparser):
+        """ add additional subparser arguments in this method if required. """
+        subparser.add_argument('--sort', action='store', help='field to sort table rows', default='sum', choices=['namespace', 'pattern', 'count', 'min', 'max', 'mean', '95%', 'sum'])
 
 
     def run(self):

--- a/mtools/mloginfo/sections/restart_section.py
+++ b/mtools/mloginfo/sections/restart_section.py
@@ -9,29 +9,16 @@ class RestartSection(BaseSection):
     """
     
     name = "restarts"
-
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --restarts flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--restarts', action='store_true', help='outputs information about every detected restart')
-
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['restarts']
+    description = "information about every detected restart"
 
 
     def run(self):
-
         if isinstance(self.mloginfo.logfile, ProfileCollection):
             print
             print "    not available for system.profile collections"
             print
             return
 
-        """ run this section and print out information. """
         for version, logevent in self.mloginfo.logfile.restarts:
             print "   %s version %s" % (logevent.datetime.strftime("%b %d %H:%M:%S"), version)
 

--- a/mtools/mloginfo/sections/threads_section.py
+++ b/mtools/mloginfo/sections/threads_section.py
@@ -1,0 +1,291 @@
+from base_section import BaseSection
+
+from mtools.util.log2code import Log2CodeConverter
+
+from collections import defaultdict
+import re
+import os
+import datetime
+
+
+class ThreadsSection(BaseSection):
+    """
+    This filter breaks the log files into separate thread files. It takes a
+    number of parameters that control the format of the outputted files.
+
+    --flatten/--[no]-flatten: These parameters control the directory structure generated.
+    If --flatten(the default) is provided then the directory structure will look something like :
+       ./threads/flat/<file 1>
+                      <file 2>
+                      <file 3>
+    That is, all the files are in a single directory.
+    If --no-flatten is specified then the directory structure will look more like :
+       ./threads/structured/<time 1>/<file 1>
+                                     <file 2>
+       ./threads/structured/<time 2>/<file 3>
+
+    That is, the files are put in a multiple directories based on the thread start time (if known).
+
+    The --bucketsize specifies an integer param (default is 1), which is the number of seconds used to
+    bucket the files in when using --no-flatten or structured.
+    In the case of --flatten OR --no-flatten, it also affects the name of file created (the thread creation time
+    is promoted to the nearest bucket).
+
+    This bucketing can be very useful when you want to find the amount of activity per unit time. It is very similar to the
+    --bucketsize parameter for the `mplotqueries --type connchurn` command.
+
+    The --out parameter specifies the output directory for the thread files, it defaults to "./threads/"
+    """
+
+    name = "threads"
+    description = 'split log file into threads'
+    log2code = Log2CodeConverter()
+
+    ACCEPTED = re.compile('^.* connection accepted from (?P<host>[a-zA-Z0-9\-\.:]+) (?P<id>#[0-9]+)')
+    ENDED = re.compile('^.* \[(?P<conn>[a-zA-Z0-9]+)\] end connection (?P<host>[a-zA-Z\-0-9\.:]+)')
+    STARTING = re.compile('^.* \[.*\] (MongoDB starting :|MongoS .* starting:) pid=')
+    FMT = '%y%H%M%S'
+
+    def _add_subparser_arguments(self, subparser):
+        """ for new version. """
+        subparser.add_argument('--flatten', action='store_true', default=True,
+                               help='split the log into separate files for every thread.')
+        subparser.add_argument('--no-flatten', action='store_false', dest='flatten',
+                               help='split the log into separate files for every thread.')
+        subparser.add_argument('--bucketsize', action='store', default=1,
+                               help='the bucket size in seconds (defaults to 1).')
+        subparser.add_argument('--out', action='store', default='./threads/',
+                                help='the output directory defaults to ./threads.')
+
+    def __init__(self, mloginfo):
+        BaseSection.__init__(self, mloginfo)
+
+        # old style arguments
+        # self.mloginfo.argparser_sectiongroup.add_argument('--threads', action='store_true',
+        #                                                   help='split file into separate files per threads')
+        # self.mloginfo.argparser_sectiongroup.add_argument('--flatten', action='store_true', default=True,
+        #                                                   help='split the log into separate files for every thread.')
+        # self.mloginfo.argparser_sectiongroup.add_argument('--no-flatten', action='store_false', dest='flatten',
+        #                                                   help='split the log into separate files for every thread.')
+        # self.mloginfo.argparser_sectiongroup.add_argument('--bucketsize', action='store', default=1,
+        #                                                   help='the bucket size in seconds (defaults to 1).')
+        # self.mloginfo.argparser_sectiongroup.add_argument('--out', action='store', default='./threads/',
+        #                                                   help='the output directory defaults to ./threads.')
+
+    @property
+    def active(self):
+        """ return boolean if this section is active. """
+        return self.mloginfo.args['threads']
+
+    def teardown(self):
+        """
+        teardown event for a filter. Since the log files may not contain all the events for a thread,
+        for example the close connection for 'conn13', we need this method to flush any remaining events
+        before the filter completes.
+        """
+        for k, lines in self.conns.items():
+            outfile = self.get_outfile(lines)
+            try:
+                f = open(outfile, 'w+')
+                for item in lines:
+                    f.write("%s\n" % item)
+            finally:
+                f.close()
+        self.conns.clear()
+
+    def flush(self, logevent):
+        """
+        If the logevent is a start event, then flush all current events (otherwise connections
+        between multiple sessions may end up in the same file and the start information for the
+        thread is lost/muddled.
+        :param logevent: the logevent to check
+        """
+        if self.STARTING.match(logevent.line_str):
+            self.teardown()
+
+    def bucket(self, time, up=False):
+        """
+        convert time to the nearest bucket.
+        :param time: the logevent time to bucket
+        :param up: round up (down is the default) or down
+        """
+        v = time
+        if self.bucketsize > 1:
+            v = int(time.strftime("%s"))
+            v -= v % self.bucketsize
+            if up:
+                v += self.bucketsize
+            v = datetime.datetime.fromtimestamp(v)
+        return v
+
+    def get_end(self, lines):
+        """
+        get the last good time for a thread. If some event lines are missing
+        then this may not be completely accurate.
+        :param lines: the log event lines for a thread
+        """
+        line = next(obj for obj in reversed(lines) if obj.datetime is not None)
+        est = line.datetime
+        st = self.bucket(est, True)
+        return st.strftime(self.FMT)
+
+    def get_start(self, lines):
+        """
+        get the first good time for a thread. If some event lines are missing then this
+        time may not be completely accurate.
+        :param lines: the log event lines for a thread
+        """
+        line = next(obj for obj in lines if obj.datetime is not None)
+        est = line.datetime
+        st = self.bucket(est)
+        return st.strftime(self.FMT)
+
+    def append(self, identifier, line):
+        """
+        add the line to the list of lines for the thread
+        :param identifier: the thread identifier , for example 'conn13' or 'initandlisten'
+        :param line: the log line event
+        :return: the lines for this identifier
+        """
+        if not identifier in self.conns:
+            self.conns[identifier] = []
+        return self.conns[identifier].append(line)
+
+    def get_outfile(self, lines):
+        """
+        generate a file name for the thread. The file name depends on a number of factors:
+            # the hostname from the first or last event
+            # the first good timestamp (and the bucketsize)
+            # the last good timestamp (and the bucketsize)
+            # the thread name
+            # the --flatten/--no-flatten flags
+        In addition to generating a file name, this method will also create the containing
+        directory if it does not already exist.
+        :param lines: the log line event
+        :return: the lines for this identifier
+        """
+        endline = lines[-1]
+        startline = lines[0]
+
+        match_data = self.ENDED.match(endline.line_str) or self.ACCEPTED.match(startline.line_str)
+        if match_data is not None:
+            frm = match_data.group('host')
+            frm = re.sub(':', '_', frm)
+        else:
+            frm = None
+
+        estamp = self.get_end(lines)
+        sstamp = self.get_start(lines)
+
+        dirname = self.out
+        p = [dirname]
+        thread = endline.thread
+        if thread is not None and thread.startswith("conn"):
+            md = self.ACCEPTED.match(endline.line_str)
+            if md is not None:
+                thread = "conn" + md.group('id')
+        if thread is None:
+            dbe = re.compile(r" dbexit:")
+            dbexit = next(obj for obj in lines if dbe.match(obj.line_str) is None)
+            if dbexit is not None:
+                thread = 'dbexit'
+            else:
+                thread = 'unknown'
+
+        name = '_'.join([x for x in [sstamp, estamp, frm, thread] if x is not None])
+        if self.flatten:
+            p += [name]
+        else:
+            p += [sstamp, name]
+
+        outfile = os.path.join(*p) + '.log'
+        directory = os.path.dirname(outfile)
+        if not os.path.exists(directory):
+            os.makedirs(os.path.dirname(outfile))
+        return outfile
+
+    def process_connect(self, logevent):
+        """
+        append the log line to the correct thread if it matches a connection  accepted event
+        :param logevent: the log line event to check
+        """
+        match_data = self.ACCEPTED.match(logevent.line_str)
+        if match_data:
+            self.append(logevent.conn, logevent)
+
+    def process_line(self, logevent):
+        """
+        append the log line to the correct thread
+        :param logevent: the log line event to check
+        """
+        self.append(logevent.thread, logevent)
+
+    def process_disconnect(self, endline):
+        """
+        flush a thread to the correct file if it matches the disconnect pattern. Delete the
+        thread from the dictionary on completion.
+        :param endline: the log line event to check
+        """
+        match_data = self.ENDED.match(endline.line_str)
+        if match_data:
+            c = endline.thread
+            outfile = self.get_outfile(self.conns[c])
+            f = open(outfile, 'w+')
+            try:
+                for item in self.conns[c]:
+                    f.write("%s\n" % item)
+                del self.conns[c]
+            finally:
+                f.close()
+
+    def process(self, logevent):
+        self.flush(logevent)
+
+        self.process_connect(logevent)
+        self.process_line(logevent)
+        self.process_disconnect(logevent)
+
+    def run(self):
+        """ go over each line in the logfile, run through log2code matcher
+            and group by matched pattern.
+        """
+
+        # old style
+        # if not self.active:
+        #   return
+        self.conns = defaultdict(lambda: 0)
+        self.bucketsize = int(self.mloginfo.args['bucketsize'])
+        self.flatten = self.mloginfo.args['flatten']
+        out = [self.mloginfo.args['out'],
+               'flat' if self.flatten else 'structured',
+               None if self.mloginfo.is_stdin else os.path.basename(self.mloginfo.logfile.name)]
+
+        self.out = os.path.join(*[x for x in out if x is not None])
+
+        progress_start = 0
+        progress_total = 1
+
+        # get log file information
+        logfile = self.mloginfo.logfile
+        if logfile.start and logfile.end and not self.mloginfo.args['verbose']:
+            progress_start = self.mloginfo._datetime_to_epoch(logfile.start)
+            progress_total = self.mloginfo._datetime_to_epoch(logfile.end) - progress_start
+        else:
+            self.mloginfo.progress_bar_enabled = False
+
+        for i, logevent in enumerate(self.mloginfo.logfile):
+            self.process(logevent)
+
+            # update progress bar every 1000 lines
+            if self.mloginfo.progress_bar_enabled and (i % 1000 == 0):
+                if logevent.datetime:
+                    progress_curr = self.mloginfo._datetime_to_epoch(logevent.datetime)
+                    self.mloginfo.update_progress(float(progress_curr - progress_start) / progress_total)
+
+        self.teardown()
+        # clear progress bar again
+        if self.mloginfo.progress_bar_enabled:
+            self.mloginfo.update_progress(1.0)
+
+        if self.mloginfo.args['verbose']:
+            print

--- a/mtools/mloginfo/sections/threads_section.py
+++ b/mtools/mloginfo/sections/threads_section.py
@@ -60,23 +60,6 @@ class ThreadsSection(BaseSection):
     def __init__(self, mloginfo):
         BaseSection.__init__(self, mloginfo)
 
-        # old style arguments
-        # self.mloginfo.argparser_sectiongroup.add_argument('--threads', action='store_true',
-        #                                                   help='split file into separate files per threads')
-        # self.mloginfo.argparser_sectiongroup.add_argument('--flatten', action='store_true', default=True,
-        #                                                   help='split the log into separate files for every thread.')
-        # self.mloginfo.argparser_sectiongroup.add_argument('--no-flatten', action='store_false', dest='flatten',
-        #                                                   help='split the log into separate files for every thread.')
-        # self.mloginfo.argparser_sectiongroup.add_argument('--bucketsize', action='store', default=1,
-        #                                                   help='the bucket size in seconds (defaults to 1).')
-        # self.mloginfo.argparser_sectiongroup.add_argument('--out', action='store', default='./threads/',
-        #                                                   help='the output directory defaults to ./threads.')
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['threads']
-
     def teardown(self):
         """
         teardown event for a filter. Since the log files may not contain all the events for a thread,
@@ -250,9 +233,6 @@ class ThreadsSection(BaseSection):
             and group by matched pattern.
         """
 
-        # old style
-        # if not self.active:
-        #   return
         self.conns = defaultdict(lambda: 0)
         self.bucketsize = int(self.mloginfo.args['bucketsize'])
         self.flatten = self.mloginfo.args['flatten']


### PR DESCRIPTION
I need both the new `mloginfo` commands and the logevent.conn so I cherry picked your change onto develop. I hope thats ok.

No tests yet and it needs some more usage testing and docs.
