### PR TITLE
fix mplotqueries --type event not working after timezone change

### DIFF
--- a/mtools/mplotqueries/mplotqueries.py
+++ b/mtools/mplotqueries/mplotqueries.py
@@ -395,7 +395,7 @@ class MPlotQueriesTool(LogFileTool):
         ylabel = ''
 
         # use timezone of first log file (may not always be what user wants but must make a choice)
-        tz = self.args['logfile'][0].timezone
+        tz = self.args['logfile'].timezone
         tzformat = '%b %d\n%H:%M:%S' if tz == tzutc() else '%b %d\n%H:%M:%S%z'
 
         locator = AutoDateLocator(tz=tz, minticks=5, maxticks=10)


### PR DESCRIPTION
```
2014-10-08T15:45:08.669+0000 [conn92] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.0.0.67:54434
2014-10-08T15:45:22.334+0000 [conn93] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.1.1.110:54242
2014-10-08T15:45:38.717+0000 [conn94] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.0.0.67:54442
2014-10-08T15:45:52.370+0000 [conn95] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.1.1.110:54246
2014-10-08T15:46:08.752+0000 [conn96] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.0.0.67:54450
2014-10-08T15:46:22.402+0000 [conn97] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.1.1.110:54253
2014-10-08T15:46:38.790+0000 [conn98] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.0.0.67:54458
2014-10-08T15:46:52.435+0000 [conn99] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.1.1.110:54259
2014-10-08T15:47:08.827+0000 [conn100] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.0.0.67:54466
2014-10-08T15:47:22.468+0000 [conn101] warning: DBException thrown :: caused by :: 9001 socket exception [CLOSED] for 10.1.1.110:54263
```

```
> mplotqueries mongod.log --type event
Traceback (most recent call last):
  File "/usr/local/bin/mplotqueries", line 10, in <module>
    execfile(__file__)
  File "/Users/gianfranco/github/rueckstiess/mtools/scripts/mplotqueries", line 472, in <module>
    tool.run()
  File "/Users/gianfranco/github/rueckstiess/mtools/scripts/mplotqueries", line 104, in run
    self.plot()
  File "/Users/gianfranco/github/rueckstiess/mtools/scripts/mplotqueries", line 398, in plot
    tz = self.args['logfile'][0].timezone
TypeError: 'LogFile' object does not support indexing
```
