### PR TITLE
set default backend to a non-X backend

### DIFF
--- a/mtools/mplotqueries/mplotqueries.py
+++ b/mtools/mplotqueries/mplotqueries.py
@@ -466,7 +466,11 @@ class MPlotQueriesTool(LogFileTool):
         plt.gcf().canvas.mpl_connect('pick_event', self.onpick)
         plt.gcf().canvas.mpl_connect('key_press_event', self.onpress)
         if self.args['output_file'] is not None:
-            plt.savefig(self.args['output_file'])
+            try:
+                plt.savefig(self.args['output_file'])
+            except Exception as e:
+                print "Error: %s" % e
+                raise SystemExit
         else:
             plt.show()
 


### PR DESCRIPTION
 and switch X on if no output-file is given (fixes #312)

Also handle exception if output-file is not in the right format
