### PR TITLE
make max line count for mlogvis plot configurable via command line

### DIFF
--- a/mtools/mlogvis/mlogvis.py
+++ b/mtools/mlogvis/mlogvis.py
@@ -29,7 +29,7 @@ class MLogVisTool(LogFileTool):
         first_row = True
         result_str = ''
         out_count = 0
-        line_max = int(self.args['line-max'])
+        line_max = int(self.args['line_max'])
         for line_no, logevent in enumerate(self.args['logfile']):
             # only export lines that have a datetime and duration
             if logevent.duration != None and logevent.datetime:

--- a/mtools/mlogvis/mlogvis.py
+++ b/mtools/mlogvis/mlogvis.py
@@ -18,6 +18,7 @@ class MLogVisTool(LogFileTool):
             a browser. Automatically opens a browser tab and shows the file.'
         self.argparser.add_argument('--no-browser', action='store_true', help='only creates .html file, but does not open the browser.')
         self.argparser.add_argument('--out', '-o', action='store', default=None, help='filename to output. Default is <original logfile>.html')
+        self.argparser.add_argument('--line-max', action='store', default='10000', help='max count of datapoints at which actual log line strings are not plotted any more.')
 
 
     def _export(self, with_line_str=True):
@@ -28,13 +29,14 @@ class MLogVisTool(LogFileTool):
         first_row = True
         result_str = ''
         out_count = 0
+        line_max = int(self.args['line-max'])
         for line_no, logevent in enumerate(self.args['logfile']):
             # only export lines that have a datetime and duration
             if logevent.duration != None and logevent.datetime:
                 out_count += 1
                 # if too many lines include a line_str, the page won't load
-                if with_line_str and out_count > 10000:
-                    print "Warning: more than 10,000 data points detected. Skipping actual log line strings for faster plotting."
+                if with_line_str and out_count > line_max:
+                    print "Warning: more than {0} data points detected. Skipping actual log line strings for faster plotting.".format(line_max)
                     return False
                 # write log line out as json
                 if not first_row:


### PR DESCRIPTION
Sometimes it could be useful to make it possible to set the max count of lines till mlogvis plots querie lines to html output. For me sometimes 10000 is  a little bit less. So it could be helpful to set it via command line.