### PR TITLE
Fix $missing operator option

### DIFF
--- a/mtools/mgenerate/mgenerate_spec.md
+++ b/mtools/mgenerate/mgenerate_spec.md
@@ -121,7 +121,7 @@ Will not insert the key/value pair. A percentage of missing values can be specif
 
 
 ###### Missing Percentage
-`{ "$missing" : { "percentage" : 30, "ifnot" : VALUE } }` <br>
+`{ "$missing" : { "percent" : 30, "ifnot" : VALUE } }` <br>
 
 Will cause the key/value pair to be missing 30% of the time, and otherwise set the VALUE for the given key.
 


### PR DESCRIPTION
It's fixed in wiki as well
https://github.com/rueckstiess/mtools/wiki/mgenerate/_compare/9dd4441582d031f0f32b08c64b203d9d4d679ca7...9faa2479c3231dc6304373db720574af57aed0fc