### PR TITLE
Fix mloginfo not ignoring log lines that don't start with a date

### DIFF
--- a/mtools/util/logevent.py
+++ b/mtools/util/logevent.py
@@ -242,11 +242,13 @@ class LogEvent(object):
                 # empty line, no need to parse datetime
                 self._datetime_calculated = True
                 return False
-
-            if not self.split_tokens[self._datetime_nextpos-1][0].isdigit():
-                # not the timestamp format that was hinted
-                _ = self.datetime
-                return False
+            try:
+                if not self.split_tokens[self._datetime_nextpos-1][0].isdigit():
+                    # not the timestamp format that was hinted
+                    _ = self.datetime
+                    return False
+            except:
+                pass
             return True
 
 


### PR DESCRIPTION
fix #357 (LogFile: handle newlines lines)