### PR TITLE
Fix for psutils zombie process exceptions on El Capitan

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1130,8 +1130,14 @@ class MLaunchTool(BaseCmdLineTool):
         process_dict = {}
 
         for p in psutil.process_iter():
+            # deal with zombie process errors in OSX
+            try:
+                name = p.name()
+            except psutil.NoSuchProcess:
+                continue
+
             # skip all but mongod / mongos
-            if p.name() not in ['mongos', 'mongod']:
+            if name not in ['mongos', 'mongod']:
                 continue
 
             port = None


### PR DESCRIPTION
See #387 for details.

The basic idea is that we have to be careful about catching NoSuchProcess errors when using psutils on El Capitan.

Please have a look and lead me know if I need to make any changes to get this submitted!