### PR TITLE
changes:

### DIFF
--- a/mtools/test/test_util_logevent.py
+++ b/mtools/test/test_util_logevent.py
@@ -69,10 +69,10 @@ def test_logevent_pattern_parsing():
     assert(le.pattern) == '{"a": 1}'
 
     le = LogEvent(line_pattern_26_b)
-    assert(le.pattern) == '{"a": 1}'
+    assert(le.pattern) == '{"a": 1}, order by: { b: 1.0 }'
 
     le = LogEvent(line_pattern_26_c)
-    assert(le.pattern) == '{"a": 1}'
+    assert(le.pattern) == '{"a": 1}, order by: { b: 1.0 }'
 
 
 def test_logevent_command_parsing():
@@ -93,10 +93,10 @@ def test_logevent_sort_pattern_parsing():
     assert(le.sort_pattern) == None
 
     le = LogEvent(line_pattern_26_b)
-    assert(le.sort_pattern) == '{"b": 1}'
+    assert(le.sort_pattern) == '{ b: 1.0 }'
 
     le = LogEvent(line_pattern_26_c)
-    assert(le.sort_pattern) == '{"b": 1}'
+    assert(le.sort_pattern) == '{ b: 1.0 }'
 
 
 def test_logevent_profile_pattern_parsing():

--- a/mtools/util/logevent.py
+++ b/mtools/util/logevent.py
@@ -5,6 +5,7 @@ import re
 import json
 
 from mtools.util.pattern import json2pattern
+from mtools.util.pattern import query_json2pattern
 
 
 class DateTimeEncoder(json.JSONEncoder):
@@ -404,7 +405,11 @@ class LogEvent(object):
 
             # trigger evaluation of operation
             if self.operation in ['query', 'getmore', 'update', 'remove'] or self.command in ['count', 'findandmodify']:
-                self._pattern = self._find_pattern('query: ')
+                self._sort_pattern = self._find_pattern('orderby: ', False)
+                if self._sort_pattern is None:
+                    self._pattern = self._get_query()
+                else:
+                    self._pattern = self._get_query() + ", order by: " + self._sort_pattern
 
         return self._pattern
 
@@ -417,7 +422,7 @@ class LogEvent(object):
 
             # trigger evaluation of operation
             if self.operation in ['query', 'getmore']:
-                self._sort_pattern = self._find_pattern('orderby: ')
+                self._sort_pattern = self._find_pattern('orderby: ', False)
 
         return self._sort_pattern
 
@@ -644,7 +649,7 @@ class LogEvent(object):
         r = self.r
 
 
-    def _find_pattern(self, trigger):
+    def _find_pattern(self, trigger, replaceValue):
 
         # get start of json query pattern
         start_idx = self.line_str.rfind(trigger)
@@ -665,11 +670,42 @@ class LogEvent(object):
             if brace_counter == 0:
                 break
         search_str = search_str[:stop_idx+1].strip()
+
         if search_str:
-            return json2pattern(search_str)
+            if replaceValue:
+              return json2pattern(search_str)
+            else:
+              return search_str
         else:
             return None
 
+    def _get_query(self):
+
+        # get start of json query pattern
+        trigger = "query: {"
+        start_idx = self.line_str.find(trigger)-1
+        if start_idx == -1:
+            # no query pattern found
+            return None
+
+        stop_idx = 0
+        brace_counter = 0
+        search_str = self.line_str[start_idx+len(trigger):]
+
+        for match in re.finditer(r'{|}', search_str):
+            stop_idx = match.start()
+            if search_str[stop_idx] == '{':
+                brace_counter += 1
+            else:
+                brace_counter -= 1
+            if brace_counter == 0:
+                break
+        search_str = search_str[:stop_idx+1].strip()
+
+        if search_str:
+            return query_json2pattern(search_str)
+        else:
+            return None
 
     def _reformat_timestamp(self, format, force=False):
         if format not in ['ctime', 'ctime-pre2.4', 'iso8601-utc', 'iso8601-local']:

--- a/mtools/util/logevent.py
+++ b/mtools/util/logevent.py
@@ -684,7 +684,7 @@ class LogEvent(object):
         # get start of json query pattern
         trigger = "query: {"
         start_idx = self.line_str.find(trigger)-1
-        if start_idx == -1:
+        if start_idx == -2:
             # no query pattern found
             return None
 


### PR DESCRIPTION
- print orderby alongside query structure
  values at orderby dictionary should not be replaced because ordering the data by {a: 1, b: 1} is different with {a: 1, b: -1}
- replace the value for $near operator
- change the approach to get the query pattern
  find the first occurence of "query: {" instead of the last occurence of "query: "
  the latter approach will fail if one of the field name at query map is "query"
  also some error messages maybe wrongly parsed if we use the latter approach