### PR TITLE
Feature print orderby

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -592,7 +592,7 @@ class MLaunchTool(BaseCmdLineTool):
             if self.args['startup']:
                 try:
                     # first try running process (startup may be modified via start command)
-                    doc['startup command'] = ' '.join(processes[doc['port']].cmdline)
+                    doc['startup command'] = ' '.join(processes[doc['port']].cmdline())
                 except KeyError:
                     # if not running, use stored startup_info
                     doc['startup command'] = startup[str(doc['port'])]

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1130,8 +1130,14 @@ class MLaunchTool(BaseCmdLineTool):
         process_dict = {}
 
         for p in psutil.process_iter():
+            # deal with zombie process errors in OSX
+            try:
+                name = p.name()
+            except psutil.NoSuchProcess:
+                continue
+
             # skip all but mongod / mongos
-            if p.name() not in ['mongos', 'mongod']:
+            if name not in ['mongos', 'mongod']:
                 continue
 
             port = None

--- a/mtools/test/test_mlogfilter.py
+++ b/mtools/test/test_mlogfilter.py
@@ -211,7 +211,7 @@ class TestMLogFilter(object):
 
     def test_accept_nodate(self):
         self.tool.is_stdin = True
-        self.tool.run('%s --from Aug 5 2014 20:53:50 --to +5min'%self.logfile_path)
+        self.tool.run('%s --from Aug 5 2015 20:53:50 --to +5min'%self.logfile_path)
         self.tool.is_stdin = False
 
         output = sys.stdout.getvalue()
@@ -398,10 +398,10 @@ class TestMLogFilter(object):
         # load year rollover logfile
         yro_logfile_path = os.path.join(os.path.dirname(mtools.__file__), 'test/logfiles/', 'year_rollover.log')
 
-        self.tool.run('%s --from Jan 1 2015 --timestamp-format iso8601-utc' % yro_logfile_path)
+        self.tool.run('%s --from Jan 1 2016 --timestamp-format iso8601-utc' % yro_logfile_path)
         output = sys.stdout.getvalue()
         for line in output.splitlines():
-            assert line.startswith("2015-")
+            assert line.startswith("2016-")
 
 
     def test_year_rollover_2(self):
@@ -414,7 +414,7 @@ class TestMLogFilter(object):
         output = sys.stdout.getvalue()
         assert len(output.splitlines()) > 0
         for line in output.splitlines():
-            assert line.startswith("2014-")
+            assert line.startswith("2015-")
 
     def test_level_225(self):
         """ mlogfilter: test that mlogfilter works levels on older logs """

--- a/mtools/test/test_util_logevent.py
+++ b/mtools/test/test_util_logevent.py
@@ -69,10 +69,10 @@ def test_logevent_pattern_parsing():
     assert(le.pattern) == '{"a": 1}'
 
     le = LogEvent(line_pattern_26_b)
-    assert(le.pattern) == '{"a": 1}'
+    assert(le.pattern) == '{"a": 1}, order by: { b: 1.0 }'
 
     le = LogEvent(line_pattern_26_c)
-    assert(le.pattern) == '{"a": 1}'
+    assert(le.pattern) == '{"a": 1}, order by: { b: 1.0 }'
 
 
 def test_logevent_command_parsing():
@@ -93,10 +93,10 @@ def test_logevent_sort_pattern_parsing():
     assert(le.sort_pattern) == None
 
     le = LogEvent(line_pattern_26_b)
-    assert(le.sort_pattern) == '{"b": 1}'
+    assert(le.sort_pattern) == '{ b: 1.0 }'
 
     le = LogEvent(line_pattern_26_c)
-    assert(le.sort_pattern) == '{"b": 1}'
+    assert(le.sort_pattern) == '{ b: 1.0 }'
 
 
 def test_logevent_profile_pattern_parsing():

--- a/mtools/test/test_util_logfile.py
+++ b/mtools/test/test_util_logfile.py
@@ -28,7 +28,7 @@ class TestUtilLogFile(object):
         for i, le in enumerate(logfile):
             assert isinstance(le, LogEvent)
 
-        assert length == i+1 
+        assert length == i+1
         assert length == 1836
 
 
@@ -36,9 +36,9 @@ class TestUtilLogFile(object):
         """ LogFile: test .start and .end property work correctly """
 
         logfile = LogFile(self.file_year_rollover)
-        
-        assert logfile.start == datetime(2014, 12, 30, 00, 13, 01, 661000, tzutc())
-        assert logfile.end == datetime(2015, 01, 02, 23, 27, 11, 720000, tzutc())
+
+        assert logfile.start == datetime(2015, 12, 30, 00, 13, 01, 661000, tzutc())
+        assert logfile.end == datetime(2016, 01, 02, 23, 27, 11, 720000, tzutc())
 
 
     def test_timezone(self):
@@ -73,7 +73,7 @@ class TestUtilLogFile(object):
         wiredtiger = open(logfile_path, 'r')
         logfile = LogFile(wiredtiger)
         assert logfile.storage_engine == 'wiredTiger'
-        
+
 
     def test_hostname_port(self):
         # mongod


### PR DESCRIPTION
changes:
- print orderby alongside query structure
  - print the raw value of orderBy
- replace the value for $near operator to 1
- change the approach to get the query pattern
  - new approach: find the first occurence of "query: {" 
  - previous approach: find the last occurence of "query: "
  - the previous approach will fail if one of the field name at query map is "query" or if it encounter some types of error messages
  - sample of problematic error message: 2016-01-17T15:35:36.529+0700 [conn11369] assertion 17287 Can't canonicalize query: BadValue bad sort specification ns:monitor.monitor.flightSearch.asfs query:{ query: {}, $readPreference: { mode: "secondaryPreferred" }, orderby: { timestamp: -2.0 } }
