### PR TITLE
Fixes csrs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,18 @@
 Changes to mtools
 =================
 
+
 #### version 1.2.2
 
+   * mloginfo: fixed showing the host in `rsstate` (#410) 
+   * mloginfo: fixed check for WT engine (#426)
+   * mlaunch: added `csrs` parameter if version > 3.3 
+   * mlaunch: Allow one node config server with --csrs and make the default be one node (#438) 
+   * mlaunch: added `shardsrv` parameter automatically (#430)
+   * mlaunch: fixed `auth` not working for replica sets (#380)
+   * mlaunch: Make sure that when CSRS is deployed, --arbiter will not have an affect on it (#418)
+   * added BinaryOperator (#405)
+   * Enabled mtools utilities to be run under debugger
 
 #### version 1.2.1
 

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -327,10 +327,14 @@ class MLaunchTool(BaseCmdLineTool):
             if first_init:
                 if self.args['csrs']:
                     # Initiate config servers in a replicaset
+                    if self.args['verbose']:
+                        print 'Initiating config server replica set.'
                     members = sorted(self.get_tagged(["config"]))
                     self._initiate_replset(members[0], "configRepl")
                 for shard in shard_names:
                     # initiate replica set on first member
+                    if self.args['verbose']:
+                        print 'Initiating shard replica set %s.' % shard
                     members = sorted(self.get_tagged([shard]))
                     self._initiate_replset(members[0], shard)
 
@@ -1126,7 +1130,9 @@ class MLaunchTool(BaseCmdLineTool):
 
     def _initiate_replset(self, port, name, maxwait=30):
         # initiate replica set
-        if not self.args['replicaset']:
+        if not self.args['replicaset'] and name != 'configRepl':
+            if self.args['verbose']:
+                print 'Skipping replica set initialization for %s' % name
             return
 
         con = MongoConnection('localhost:%i'%port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ python-dateutil==2.2
 matplotlib==1.3.1
 nose==1.3.0
 numpy==1.8.0
-pymongo==2.6.3
+pymongo==3.3.0
 psutil>=2.0


### PR DESCRIPTION
Fixed #439, #438 
Added verbose debug statements from a comment on #437 
Updated change log as per updates from git log
"csrs" is used by default when version > 3.3.0
Again, by default, only one config server is created (a replica set of one if "csrs")
The on-line documentation still needs to be updated to describe the the "csrs" parameter