### PR TITLE
Fixed incorrect timestamp processing in LogEvent

### DIFF
--- a/mtools/test/test_util_logevent.py
+++ b/mtools/test/test_util_logevent.py
@@ -6,9 +6,9 @@ import datetime
 from dateutil import parser
 
 line_ctime_pre24 = "Sun Aug  3 21:52:05 [initandlisten] db version v2.2.4, pdfile version 4.5"
-line_ctime = "Sun Aug  3 21:52:05.995 [initandlisten] db version v2.4.5"
-line_iso8601_local = "2013-08-03T21:52:05.995+1000 [initandlisten] db version v2.5.2-pre-"
-line_iso8601_utc = "2013-08-03T11:52:05.995Z [initandlisten] db version v2.5.2-pre-"
+line_ctime = "Sun Aug  3 21:52:05.095 [initandlisten] db version v2.4.5"
+line_iso8601_local = "2013-08-03T21:52:05.095+1000 [initandlisten] db version v2.5.2-pre-"
+line_iso8601_utc = "2013-08-03T11:52:05.095Z [initandlisten] db version v2.5.2-pre-"
 line_getmore = "Mon Aug  5 20:26:32 [conn9] getmore local.oplog.rs query: { ts: { $gte: new Date(5908578361554239489) } } cursorid:1870634279361287923 ntoreturn:0 keyUpdates:0 numYields: 107 locks(micros) r:85093 nreturned:13551 reslen:230387 144ms"
 line_253_numYields = "2013-10-21T12:07:27.057+1100 [conn2] query test.docs query: { foo: 234333.0 } ntoreturn:0 ntoskip:0 keyUpdates:0 numYields:1 locks(micros) r:239078 nreturned:0 reslen:20 145ms"
 line_246_numYields = "Mon Oct 21 12:14:21.888 [conn4] query test.docs query: { foo: 23432.0 } ntoreturn:0 ntoskip:0 nscanned:316776 keyUpdates:0 numYields: 2405 locks(micros) r:743292 nreturned:2 reslen:2116 451ms"
@@ -40,7 +40,7 @@ def test_logevent_datetime_parsing():
 
     le =  LogEvent(line_ctime)
     le_str = le.line_str
-    assert(str(le.datetime) == '%s-08-03 21:52:05.995000+00:00'%this_year)
+    assert(str(le.datetime) == '%s-08-03 21:52:05.095000+00:00'%this_year)
     assert(le._datetime_format == 'ctime')
     assert(le.line_str[4:] == le_str[4:])
     # make sure all datetime objects are timezone aware
@@ -48,7 +48,7 @@ def test_logevent_datetime_parsing():
 
     le =  LogEvent(line_iso8601_utc)
     le_str = le.line_str
-    assert(str(le.datetime) == '2013-08-03 11:52:05.995000+00:00')
+    assert(str(le.datetime) == '2013-08-03 11:52:05.095000+00:00')
     assert(le._datetime_format == 'iso8601-utc')
     assert(le.line_str[4:] == le_str[4:])
     # make sure all datetime objects are timezone aware
@@ -56,7 +56,7 @@ def test_logevent_datetime_parsing():
 
     le =  LogEvent(line_iso8601_local)
     le_str = le.line_str
-    assert(str(le.datetime) == '2013-08-03 21:52:05.995000+10:00')
+    assert(str(le.datetime) == '2013-08-03 21:52:05.095000+10:00')
     assert(le._datetime_format == 'iso8601-local')
     assert(le.line_str[4:] == le_str[4:])
     # make sure all datetime objects are timezone aware

--- a/mtools/util/logevent.py
+++ b/mtools/util/logevent.py
@@ -692,7 +692,7 @@ class LogEvent(object):
             dt_string = self.datetime.isoformat()
             if self.datetime.utcoffset() == None:
                 dt_string += '+00:00'
-            ms_str = str(int(self.datetime.microsecond * 1000)).zfill(3)[:3]
+            ms_str = str(int(self.datetime.microsecond / 1000)).zfill(3)[:3]
             # change isoformat string to have 3 digit milliseconds and no : in offset
             dt_string = re.sub(r'(\.\d+)?([+-])(\d\d):(\d\d)', '.%s\\2\\3\\4'%ms_str, dt_string, count=1)
         elif format == 'iso8601-utc':
@@ -700,7 +700,7 @@ class LogEvent(object):
                 dt_string = self.datetime.astimezone(tzutc()).strftime("%Y-%m-%dT%H:%M:%S")
             else:
                 dt_string = self.datetime.strftime("%Y-%m-%dT%H:%M:%S")
-            dt_string += '.' + str(int(self.datetime.microsecond * 1000)).zfill(3)[:3] + 'Z'
+            dt_string += '.' + str(int(self.datetime.microsecond / 1000)).zfill(3)[:3] + 'Z'
 
         # set new string and format
         self._datetime_str = dt_string


### PR DESCRIPTION
LogEvent timestamp were wrongly calculated, resulting in this log line:

```
2017-08-25T22:23:49.097+0000 I COMMAND [conn0]
```

to be rendered like this:

```
2017-08-25T22:23:49.970+0000 I COMMAND [conn0]
```

Note that `097` changed to `970` in the processed line.

This was not noticed for a long while, and the tests passed because the tests were using a timestamp of:

```
2013-08-03T21:52:05.995+1000
```

which due to the bug, was processed correctly.

I have fixed the timestamp processing and updated the test.