### PR TITLE
Better error if --binarypath is wrong

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -469,6 +469,8 @@ class MLaunchTool(BaseCmdLineTool):
             binary = os.path.join(self.args['binarypath'], binary)
         ret = subprocess.Popen(['%s --version' % binary], stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
         out, err = ret.communicate()
+        if ret.returncode:
+            raise OSError(out or err)
         buf = StringIO(out)
         current_version = buf.readline().rstrip('\n')
         # remove prefix "db version v"


### PR DESCRIPTION
Log "no such file or directory" instead of "ValueError: substring not
found".