### PR TITLE
Fix #429: mloginfo and other tools should check if the log file passed in is a valid log

### DIFF
--- a/mtools/test/test_mlogfilter.py
+++ b/mtools/test/test_mlogfilter.py
@@ -201,6 +201,12 @@ class TestMLogFilter(object):
             le = LogEvent(line)
             assert(le.duration >= 145 and le.duration <= 500)
 
+    @raises(SystemExit)
+    def test_invalid_log(self):
+        # load text file
+        invalid_logfile_path = os.path.join(os.path.dirname(mtools.__file__), '../', 'requirements.txt')
+        self.tool.run('%s' % invalid_logfile_path)
+
     def test_scan(self):
         # load tablescan logfile
         scn_logfile_path = os.path.join(os.path.dirname(mtools.__file__), 'test/logfiles/', 'collscans.log')

--- a/mtools/util/logfile.py
+++ b/mtools/util/logfile.py
@@ -362,8 +362,6 @@ class LogFile(InputSource):
         if self._bounds_calculated:
             # Assume no need to recalc bounds for lifetime of a Logfile object
             return
-        else:
-            self._bounds_calculated = True
 
         if self.from_stdin: 
             return False
@@ -411,6 +409,7 @@ class LogFile(InputSource):
 
         # reset logfile
         self.filehandle.seek(0)
+        self._bounds_calculated = True
 
         return True
 

--- a/mtools/util/logfile.py
+++ b/mtools/util/logfile.py
@@ -16,6 +16,7 @@ class LogFile(InputSource):
         self.name = filehandle.name
         
         self.from_stdin = filehandle.name == "<stdin>"
+        self._bounds_calculated = False
         self._start = None
         self._end = None
         self._filesize = None
@@ -358,18 +359,37 @@ class LogFile(InputSource):
     def _calculate_bounds(self):
         """ calculate beginning and end of logfile. """
 
+        if self._bounds_calculated:
+            # Assume no need to recalc bounds for lifetime of a Logfile object
+            return
+        else:
+            self._bounds_calculated = True
+
         if self.from_stdin: 
             return False
 
-        # get start datetime 
+        # we should be able to find a valid log line within max_start_lines
+        max_start_lines = 10
+        lines_checked = 0
+
+        # get start datetime
         for line in self.filehandle:
             logevent = LogEvent(line)
+            lines_checked += 1
             if logevent.datetime:
                 self._start = logevent.datetime
                 self._timezone = logevent.datetime.tzinfo
                 self._datetime_format = logevent.datetime_format
                 self._datetime_nextpos = logevent._datetime_nextpos
                 break
+            if lines_checked > max_start_lines:
+                break
+
+        # sanity check before attempting to find end date
+        if (self._start is None):
+            raise SystemExit(
+                "Error: <%s> does not appear to be a supported MongoDB log file format" % self.filehandle.name
+            )
 
         # get end datetime (lines are at most 10k, go back 30k at most to make sure we catch one)
         self.filehandle.seek(0, 2)


### PR DESCRIPTION
* Added a sanity check to exit if no valid log lines are found at the beginning of a file:
> Error: < filename > does not appear to be a supported MongoDB log file format
* Skip repeated calculation of details for a log file; the lazy evaluation of properties could trigger multiple futile calculations for missing properties