### PR TITLE
mlanunch: Make 8th+ replica set members non-voting

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1512,6 +1512,10 @@ class MLaunchTool(BaseCmdLineTool):
             if i == 0 and self.args['priority']:
                 member_config['priority'] = 10
 
+            if i >= 7:
+	        member_config['votes'] = 0
+	        member_config['priority'] = 0
+
             self.config_docs[name]['members'].append(member_config)
 
         # launch arbiter if True


### PR DESCRIPTION
Replica sets can have up to 7 voting members[1].
This change allows spinning up replica sets with more than 7 members by forcing
zero votes starting from the 8th node.

[1] https://docs.mongodb.com/manual/reference/limits/#replica-sets