### PR TITLE
Fix #476: Error while creating replica set with name and auth args

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1387,8 +1387,8 @@ class MLaunchTool(BaseCmdLineTool):
 
     def _wait_for_primary(self):
 
-        hosts = [x['host'] for x in self.config_docs['replset']['members']]
-        rs_name = self.config_docs['replset']['_id']
+        hosts = [x['host'] for x in self.config_docs[self.args['name']]['members']]
+        rs_name = self.config_docs[self.args['name']]['_id']
         mrsc = self.client(hosts, replicaSet=rs_name,
                            serverSelectionTimeoutMS=30000)
 

--- a/mtools/test/test_mlaunch.py
+++ b/mtools/test/test_mlaunch.py
@@ -596,8 +596,21 @@ class TestMLaunch(object):
 
         self.use_auth = False
 
+    @attr('auth')
+    def test_replicaset_with_name(self):
+        """ mlaunch: test calling init on the replica set with given name """
+
+        self.run_tool("init --replicaset --name testrs")
+
+        # create mongo client for the next tests
+        mc = MongoClient('localhost:%i' % self.port)
+
+        # get rs.conf() and check for its name
+        conf = mc['local']['system.replset'].find_one()
+        assert conf['_id'] == 'testrs'
+
     # TODO 
-    # - test functionality of --binarypath, --verbose, --name
+    # - test functionality of --binarypath, --verbose
 
     # All tests that use auth need to be decorated with @attr('auth')
 


### PR DESCRIPTION
   * index value for config_docs is now taken from args
   * Add simple test for --name parameter

## Description of changes
 Index value for config_docs is now taken from args istead of fixed value.


## Testing
 Tested by manually creating named replicaset with --auth directly from commandline.
 Unit test written aswell.


O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 

