### PR TITLE
Fix #543: Enable tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: python
-python:
-  - "2.7"
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install:
-  - pip install .
-  - pip install -r requirements.txt --allow-insecure matplotlib
-# command to run tests, e.g. python setup.py test
-script: nosetests
-sudo: false
+python: "2.7"
+install: pip install tox
+script: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-argparse
-ordereddict
-python-dateutil
+argparse==1.2.1
+ordereddict==1.1
+python-dateutil==2.2
 matplotlib==1.3.1
 numpy==1.8.0
-pymongo
-psutil
+pymongo>=3.3.0
+psutil>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-ordereddict==1.1
-argparse==1.2.1
-python-dateutil==2.2
+argparse
+ordereddict
+python-dateutil
 matplotlib==1.3.1
-nose>=1.3.0
 numpy==1.8.0
-pymongo>=3.3.0
-psutil>=2.0
+pymongo
+psutil

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ try:
     # the default install experience, particularly where a build toolchain is
     # required.
     extras_requires = {
-        "all": ['matplotlib>=1.3.1', 'numpy>=1.8.0', 'pymongo>=3.3'],
-        "mlaunch": ['pymongo>=3.3'],
+        "all": ['matplotlib>=1.3.1', 'numpy>=1.8.0', 'pymongo>=3.3', 'psutil>=2.0'],
+        "mlaunch": ['pymongo>=3.3', 'psutil>=2.0'],
         "mlogfilter": [],
         "mloginfo": ['numpy>=1.8.0'],
         "mlogvis": [],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-# nose tests require multiprocessing package, see
-# https://groups.google.com/forum/#!msg/nose-users/fnJ-kAUbYHQ/_UsLN786ygcJ
-import multiprocessing
 import sys
 import platform
 import re
@@ -25,7 +22,6 @@ try:
         "mplotqueries": ['matplotlib>=1.3.1', 'numpy>=1.8.0'],
     }
 
-    test_requires = ['nose>=1.3.0', 'psutil>=2.0', 'pymongo>=3.3']
     try:
         import argparse
     except ImportError:
@@ -35,14 +31,12 @@ try:
         from collections import OrderedDict
     except ImportError:
         install_requires.append('ordereddict')
-        test_requires.append('ordereddict')
 
     # add dateutil if not installed already
     try:
         import dateutil
     except ImportError:
         install_requires.append('python-dateutil==2.2')
-        test_requires.append('python-dateutil==2.2')
 
     packages = find_packages()
     kws = {'install_requires': install_requires}
@@ -114,7 +108,5 @@ setup(
     ],
     keywords='MongoDB logs testing',
     extras_require=extras_requires,
-    tests_require=test_requires,
-    test_suite = 'nose.collector',
     **kws
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+coverage
+nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,32 @@
+[tox]
+minversion = 2.3
+envlist = py27
+skipsdist = True
+
+[testenv]
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+commands = nosetests -d --with-coverage --cover-package=mtools
+
+[testenv:flake8]
+deps =
+    pep8-naming
+    flake8
+commands = flake8 --max-complexity 10
+
+[testenv:isort]
+deps = isort
+commands = isort -c -s .tox
+
+[testenv:pep257]
+deps = pep257
+commands = pep257
+
+[flake8]
+show-source = True
+# H803 skipped (commit subject must not end with period)
+# E123, E125 skipped as they are invalid PEP-8.
+ignore = E123,E125,H803
+builtins = _
+exclude=setup.py,.venv,.git,.tox,dist,*lib/python*,*egg,*figures/*


### PR DESCRIPTION
- remove current test lines from setup.py
- add tox.ini
- add test-requirements.txt
- add coverage report
- add flake8 with pep8-naming, isort, and pep257 as testenvs
- update .travis.yml