### PR TITLE
Fix for #554: Using --hostname with mlaunch in 3.6 causes deploying failure

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1938,9 +1938,9 @@ class MLaunchTool(BaseCmdLineTool):
 
         # Exit with error if hostname is specified but not bind_ip options
         if (self.args['hostname'] != 'localhost'
-            and LooseVersion(current_version) >= LooseVersion("3.6.0")
-            and (self.args['sharded'] or self.args['replicaset'])
-            and '--bind_ip' not in extra):
+                and LooseVersion(current_version) >= LooseVersion("3.6.0")
+                and (self.args['sharded'] or self.args['replicaset'])
+                and '--bind_ip' not in extra):
             os.removedirs(dbpath)
             errmsg = " \n * If hostname is specified, please include '--bind_ip_all' or '--bind_ip' options when deploying replica sets or sharded cluster with MongoDB version 3.6.0 or greater"
             raise SystemExit(errmsg)

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1934,6 +1934,17 @@ class MLaunchTool(BaseCmdLineTool):
                                              'mongod')):
             extra += ' --wiredTigerCacheSizeGB 1 '
 
+        current_version = self.getMongoDVersion()
+
+        # Exit with error if hostname is specified but not bind_ip options
+        if (self.args['hostname'] != 'localhost'
+            and LooseVersion(current_version) >= LooseVersion("3.6.0")
+            and (self.args['sharded'] or self.args['replicaset'])
+            and '--bind_ip' not in extra):
+            os.removedirs(dbpath)
+            errmsg = " \n * If hostname is specified, please include '--bind_ip_all' or '--bind_ip' options when deploying replica sets or sharded cluster with MongoDB version 3.6.0 or greater"
+            raise SystemExit(errmsg)
+
         extra += self._get_ssl_server_args()
 
         path = self.args['binarypath'] or ''

--- a/mtools/test/test_mlaunch_commandlines.py
+++ b/mtools/test/test_mlaunch_commandlines.py
@@ -101,6 +101,11 @@ class TestMLaunch(object):
         if LooseVersion(self.mongod_version) < LooseVersion('3.4.0'):
             raise SkipTest('MongoDB version is < 3.4.0')
 
+    def check_3_6(self):
+        """Check for MongoDB 3.6, skip test otherwise."""
+        if LooseVersion(self.mongod_version) < LooseVersion('3.6.0'):
+            raise SkipTest('MongoDB version is < 3.6.0')
+
     # Tests
 
     def test_single(self):
@@ -492,3 +497,12 @@ class TestMLaunch(object):
             [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
+
+    @raises(IOError)
+    def test_hostname_3_6(self):
+        """
+        mlaunch should not start if hostname is specified but not bind_ip.
+        """
+        self.check_3_6()
+        self.run_tool('init --replicaset --hostname this_host')
+        self.read_config()


### PR DESCRIPTION
Rebased PR #555, added test for the PR.