### PR TITLE
Allow starting 3.6 clusters with PyMongo 3.6.1

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1253,7 +1253,8 @@ class MLaunchTool(BaseCmdLineTool):
             con = self.client('localhost:%s' % port)
             con.admin.command('ping')
             return True
-        except (AutoReconnect, ConnectionFailure):
+        except (AutoReconnect, ConnectionFailure, OperationFailure):
+            # Catch OperationFailure to work around SERVER-31916.
             return False
 
     def get_tagged(self, tags):


### PR DESCRIPTION
## Description of changes
Work around [SERVER-31916](https://jira.mongodb.org/browse/SERVER-31916).

## Testing

Before this change starting a 3.6 replica set or sharded cluster with auth fails with the following error:

```
$ python -m mtools.mlaunch.mlaunch init --replicaset --node 2 --auth --verbose --hostname localhost
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/replset/rs1/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/replset/rs2/db
Detected mongod version: 3.6.3
writing .mlaunch_startup file.
waiting for nodes to shutdown...
launching: mongod --replSet replset --dbpath /Users/shane/tmp-mtools/data/replset/rs1/db --logpath /Users/shane/tmp-mtools/data/replset/rs1/mongod.log --port 27017 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile  --wiredTigerCacheSizeGB 1
launching: mongod --replSet replset --dbpath /Users/shane/tmp-mtools/data/replset/rs2/db --logpath /Users/shane/tmp-mtools/data/replset/rs2/mongod.log --port 27018 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile  --wiredTigerCacheSizeGB 1
waiting for nodes to start...
initializing replica set 'replset' with configuration: {'_id': 'replset', 'members': [{'host': 'localhost:27017', '_id': 0}, {'host': 'localhost:27018', '_id': 1}]}
replica set 'replset' initialized.
waiting for nodes to start...
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.14_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.14_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/shane/git/mtools/mtools/mlaunch/mlaunch.py", line 2019, in <module>
    sys.exit(main())
  File "/Users/shane/git/mtools/mtools/mlaunch/mlaunch.py", line 2015, in main
    tool.run()
  File "/Users/shane/git/mtools/mtools/mlaunch/mlaunch.py", line 533, in run
    getattr(self, self.args['command'])()
  File "/Users/shane/git/mtools/mtools/mlaunch/mlaunch.py", line 711, in init
    self.discover()
  File "/Users/shane/git/mtools/mtools/mlaunch/mlaunch.py", line 1149, in discover
    running = self.is_running(port)
  File "/Users/shane/git/mtools/mtools/mlaunch/mlaunch.py", line 1254, in is_running
    con.admin.command('ping')
  File "/Users/shane/git/mongo-python-driver/pymongo/database.py", line 532, in command
    codec_options, session=session, **kwargs)
  File "/Users/shane/git/mongo-python-driver/pymongo/database.py", line 439, in _command
    client=self.__client)
  File "/Users/shane/git/mongo-python-driver/pymongo/pool.py", line 517, in command
    collation=collation)
  File "/Users/shane/git/mongo-python-driver/pymongo/network.py", line 125, in command
    parse_write_concern_error=parse_write_concern_error)
  File "/Users/shane/git/mongo-python-driver/pymongo/helpers.py", line 145, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
pymongo.errors.OperationFailure: Cache Reader No keys found for HMAC that is valid for time: { ts: Timestamp(1519935856, 1) } with id: 0
```

After this change: 
```
$  python -m mtools.mlaunch.mlaunch init --replicaset --node 2 --auth --verbose --hostname localhost
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/replset/rs1/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/replset/rs2/db
Detected mongod version: 3.6.3
writing .mlaunch_startup file.
waiting for nodes to shutdown...
launching: mongod --replSet replset --dbpath /Users/shane/tmp-mtools/data/replset/rs1/db --logpath /Users/shane/tmp-mtools/data/replset/rs1/mongod.log --port 27017 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile  --wiredTigerCacheSizeGB 1
launching: mongod --replSet replset --dbpath /Users/shane/tmp-mtools/data/replset/rs2/db --logpath /Users/shane/tmp-mtools/data/replset/rs2/mongod.log --port 27018 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile  --wiredTigerCacheSizeGB 1
waiting for nodes to start...
initializing replica set 'replset' with configuration: {'_id': 'replset', 'members': [{'host': 'localhost:27017', '_id': 0}, {'host': 'localhost:27018', '_id': 1}]}
replica set 'replset' initialized.
waiting for nodes to start...
waiting for primary to add a user.
added user user on admin database
Username "user", password "password"
done.
```
After this change sharded cluster with auth:
```
$ python -m mtools.mlaunch.mlaunch init --replicaset --node 2 --sharded 3 --auth --verbose --hostname localhost
Detected mongod version: 3.6.3
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/shard01/rs1/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/shard01/rs2/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/shard02/rs1/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/shard02/rs2/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/shard03/rs1/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/shard03/rs2/db
Detected mongod version: 3.6.3
creating directory: /Users/shane/tmp-mtools/data/configRepl/rs1/db
Detected mongod version: 3.6.3
writing .mlaunch_startup file.
waiting for nodes to shutdown...
creating cluster without auth for setup, will enable auth at the end...
launching: mongod --replSet shard01 --dbpath /Users/shane/tmp-mtools/data/shard01/rs1/db --logpath /Users/shane/tmp-mtools/data/shard01/rs1/mongod.log --port 27018 --fork  --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard01 --dbpath /Users/shane/tmp-mtools/data/shard01/rs2/db --logpath /Users/shane/tmp-mtools/data/shard01/rs2/mongod.log --port 27019 --fork  --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard02 --dbpath /Users/shane/tmp-mtools/data/shard02/rs1/db --logpath /Users/shane/tmp-mtools/data/shard02/rs1/mongod.log --port 27020 --fork  --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard02 --dbpath /Users/shane/tmp-mtools/data/shard02/rs2/db --logpath /Users/shane/tmp-mtools/data/shard02/rs2/mongod.log --port 27021 --fork  --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard03 --dbpath /Users/shane/tmp-mtools/data/shard03/rs1/db --logpath /Users/shane/tmp-mtools/data/shard03/rs1/mongod.log --port 27022 --fork  --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard03 --dbpath /Users/shane/tmp-mtools/data/shard03/rs2/db --logpath /Users/shane/tmp-mtools/data/shard03/rs2/mongod.log --port 27023 --fork  --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet configRepl --dbpath /Users/shane/tmp-mtools/data/configRepl/rs1/db --logpath /Users/shane/tmp-mtools/data/configRepl/rs1/mongod.log --port 27024 --fork  --configsvr --wiredTigerCacheSizeGB 1
waiting for nodes to start...
Initiating config server replica set.
initializing replica set 'configRepl' with configuration: {'_id': 'configRepl', 'members': [{'host': 'localhost:27024', '_id': 0}]}
replica set 'configRepl' initialized.
Initiating shard replica set shard01.
initializing replica set 'shard01' with configuration: {'_id': 'shard01', 'members': [{'host': 'localhost:27018', '_id': 0}, {'host': 'localhost:27019', '_id': 1}]}
replica set 'shard01' initialized.
Initiating shard replica set shard02.
initializing replica set 'shard02' with configuration: {'_id': 'shard02', 'members': [{'host': 'localhost:27020', '_id': 0}, {'host': 'localhost:27021', '_id': 1}]}
replica set 'shard02' initialized.
Initiating shard replica set shard03.
initializing replica set 'shard03' with configuration: {'_id': 'shard03', 'members': [{'host': 'localhost:27022', '_id': 0}, {'host': 'localhost:27023', '_id': 1}]}
replica set 'shard03' initialized.
creating cluster without auth for setup, will enable auth at the end...
launching: mongos --logpath /Users/shane/tmp-mtools/data/mongos.log --port 27017 --configdb configRepl/localhost:27024    --fork
waiting for nodes to start...
adding shards. can take up to 30 seconds...
shard shard01/localhost:27018,localhost:27019 added successfully
shard shard02/localhost:27020,localhost:27021 added successfully
shard shard03/localhost:27022,localhost:27023 added successfully
waiting for nodes to start...
added user user on admin database
restarting cluster to enable auth...
 <bound method Process.name of psutil.Process(pid=34418, name='mongos', started='12:32:14')> on port 27017, pid=34418
 <bound method Process.name of psutil.Process(pid=34396, name='mongod', started='12:32:05')> on port 27018, pid=34396
 <bound method Process.name of psutil.Process(pid=34399, name='mongod', started='12:32:06')> on port 27019, pid=34399
 <bound method Process.name of psutil.Process(pid=34402, name='mongod', started='12:32:07')> on port 27020, pid=34402
 <bound method Process.name of psutil.Process(pid=34405, name='mongod', started='12:32:08')> on port 27021, pid=34405
 <bound method Process.name of psutil.Process(pid=34408, name='mongod', started='12:32:09')> on port 27022, pid=34408
 <bound method Process.name of psutil.Process(pid=34411, name='mongod', started='12:32:11')> on port 27023, pid=34411
 <bound method Process.name of psutil.Process(pid=34414, name='mongod', started='12:32:12')> on port 27024, pid=34414
sent signal 15 to 8 processes.
launching: mongod --replSet configRepl --dbpath /Users/shane/tmp-mtools/data/configRepl/rs1/db --logpath /Users/shane/tmp-mtools/data/configRepl/rs1/mongod.log --port 27024 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile --configsvr --wiredTigerCacheSizeGB 1
waiting for nodes to start...
launching: mongod --replSet shard01 --dbpath /Users/shane/tmp-mtools/data/shard01/rs1/db --logpath /Users/shane/tmp-mtools/data/shard01/rs1/mongod.log --port 27018 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard01 --dbpath /Users/shane/tmp-mtools/data/shard01/rs2/db --logpath /Users/shane/tmp-mtools/data/shard01/rs2/mongod.log --port 27019 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard02 --dbpath /Users/shane/tmp-mtools/data/shard02/rs1/db --logpath /Users/shane/tmp-mtools/data/shard02/rs1/mongod.log --port 27020 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard02 --dbpath /Users/shane/tmp-mtools/data/shard02/rs2/db --logpath /Users/shane/tmp-mtools/data/shard02/rs2/mongod.log --port 27021 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard03 --dbpath /Users/shane/tmp-mtools/data/shard03/rs1/db --logpath /Users/shane/tmp-mtools/data/shard03/rs1/mongod.log --port 27022 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile --shardsvr --wiredTigerCacheSizeGB 1
launching: mongod --replSet shard03 --dbpath /Users/shane/tmp-mtools/data/shard03/rs2/db --logpath /Users/shane/tmp-mtools/data/shard03/rs2/mongod.log --port 27023 --fork --keyFile /Users/shane/tmp-mtools/data/keyfile --shardsvr --wiredTigerCacheSizeGB 1
waiting for nodes to start...
launching: mongos --logpath /Users/shane/tmp-mtools/data/mongos.log --port 27017 --configdb configRepl/localhost:27024 --keyFile /Users/shane/tmp-mtools/data/keyfile   --fork
waiting for nodes to start...
Username "user", password "password"
done.
```

All tests were run with PyMongo 3.6.0 and PyMongo 3.6.1 (which should be released today) and MongoDB 3.6.3.

O/S testing:
| O/S       | Version(s) |
| --------- | ---------- |
| Linux     | Not tested |
| macOS     | 10.13.3    |
| Windows   | Not tested |

CC: @renatoriccio, @behackett