### PR TITLE
Force `mlaunch --csrs` when "version" is `0.0.0`

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -567,14 +567,16 @@ class MLaunchTool(BaseCmdLineTool):
 
         # Exit with error if --csrs is set and MongoDB < 3.1.0
         if (self.args['csrs'] and
-                LooseVersion(current_version) < LooseVersion("3.1.0")):
+                LooseVersion(current_version) < LooseVersion("3.1.0") and
+                LooseVersion(current_version) != LooseVersion("0.0.0")):
             errmsg = (" \n * The '--csrs' option requires MongoDB version "
                       "3.2.0 or greater, the current version is %s.\n"
                       % current_version)
             raise SystemExit(errmsg)
 
         # add the 'csrs' parameter as default for MongoDB >= 3.3.0
-        if LooseVersion(current_version) >= LooseVersion("3.3.0"):
+        if (LooseVersion(current_version) >= LooseVersion("3.3.0") or
+            LooseVersion(current_version) == LooseVersion("0.0.0")):
             self.args['csrs'] = True
 
         # construct startup strings


### PR DESCRIPTION
This (fake) version is commonly used when compiling development versions of the
MongoDB server (via `scons MONGO_VERSION=0.0.0`) (as a way of avoiding
unnecessarily rebuilding version-related object files after each commit).
However, a mongod version of `0.0.0` caused `mlaunch --csrs` to exit, since
(apparently) `"0.0.0" < "3.1.0"`.  This prevented `mlaunch --sharded` from
launching sharded clusters of current development versions of MongoDB which
have been compiled this way.

This change makes mlaunch use `--csrs` when the mongod version is `0.0.0`,
which allows it to work correctly with all currently supported server branches
(v3.2, v3.4, v3.6, master) that have been compiled with `MONGO_VERSION=0.0.0`.

<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->


## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->


O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            | 
| Windows          |
