### PR TITLE
Handle spaces in mlaunch `binarypath` parameter in Unix and Windows.

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1606,7 +1606,7 @@ class MLaunchTool(BaseCmdLineTool):
 
             try:
                 if os.name == 'nt':
-                    ret = subprocess.check_call([_f for _f in command_str.split(' ') if _f],
+                    ret = subprocess.check_call(command_str,
                                                 shell=True)
                     # create sub process on windows doesn't wait for output,
                     # wait a few seconds for mongod instance up
@@ -1971,8 +1971,8 @@ class MLaunchTool(BaseCmdLineTool):
         if os.name == 'nt':
             newdbpath = dbpath.replace('\\', '\\\\')
             newlogpath = logpath.replace('\\', '\\\\')
-            command_str = ("start /b \"%s\" %s --dbpath %s --logpath %s --port %i "
-                           "%s %s" % (os.path.join(path, 'mongod'),
+            command_str = ("start /b \"\" \"%s\" %s --dbpath %s --logpath %s --port %i "
+                           "%s %s" % (os.path.join(path, 'mongod.exe'),
                                       rs_param, newdbpath, newlogpath, port,
                                       auth_param, extra))
         else:

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -783,7 +783,7 @@ class MLaunchTool(BaseCmdLineTool):
         binary = "mongod"
         if self.args and self.args.get('binarypath'):
             binary = os.path.join(self.args['binarypath'], binary)
-        ret = subprocess.Popen([binary, '--version'],
+        ret = subprocess.Popen(['%s' % binary, '--version'],
                                stderr=subprocess.STDOUT,
                                stdout=subprocess.PIPE, shell=False)
         out, err = ret.communicate()
@@ -1468,7 +1468,7 @@ class MLaunchTool(BaseCmdLineTool):
         # get the help list of the binary
         if self.args and self.args['binarypath']:
             binary = os.path.join(self.args['binarypath'], binary)
-        ret = (subprocess.Popen([binary, '--help'],
+        ret = (subprocess.Popen(['%s' % binary, '--help'],
                stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=False))
 
         out, err = ret.communicate()
@@ -1971,12 +1971,12 @@ class MLaunchTool(BaseCmdLineTool):
         if os.name == 'nt':
             newdbpath = dbpath.replace('\\', '\\\\')
             newlogpath = logpath.replace('\\', '\\\\')
-            command_str = ("start /b %s %s --dbpath %s --logpath %s --port %i "
+            command_str = ("start /b \"%s\" %s --dbpath %s --logpath %s --port %i "
                            "%s %s" % (os.path.join(path, 'mongod'),
                                       rs_param, newdbpath, newlogpath, port,
                                       auth_param, extra))
         else:
-            command_str = ("%s %s --dbpath %s --logpath %s --port %i --fork "
+            command_str = ("\"%s\" %s --dbpath %s --logpath %s --port %i --fork "
                            "%s %s" % (os.path.join(path, 'mongod'), rs_param,
                                       dbpath, logpath, port, auth_param,
                                       extra))

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1971,12 +1971,12 @@ class MLaunchTool(BaseCmdLineTool):
         if os.name == 'nt':
             newdbpath = dbpath.replace('\\', '\\\\')
             newlogpath = logpath.replace('\\', '\\\\')
-            command_str = ("start /b \"\" \"%s\" %s --dbpath %s --logpath %s --port %i "
+            command_str = ("start /b \"\" \"%s\" %s --dbpath \"%s\" --logpath \"%s\" --port %i "
                            "%s %s" % (os.path.join(path, 'mongod.exe'),
                                       rs_param, newdbpath, newlogpath, port,
                                       auth_param, extra))
         else:
-            command_str = ("\"%s\" %s --dbpath %s --logpath %s --port %i --fork "
+            command_str = ("\"%s\" %s --dbpath \"%s\" --logpath \"%s\" --port %i --fork "
                            "%s %s" % (os.path.join(path, 'mongod'), rs_param,
                                       dbpath, logpath, port, auth_param,
                                       extra))

--- a/mtools/test/test_mlaunch_commandlines.py
+++ b/mtools/test/test_mlaunch_commandlines.py
@@ -48,6 +48,7 @@ class TestMLaunch(object):
 
     def cmdlist_filter(self, cmdlist):
         """Filter command lines to contain only [mongod|mongos] --parameter."""
+        # NOTE: The command "mongo was intentionally written with a leading quote
         res = map(lambda cmd: set([param for param in cmd.split()
                                    if param.startswith('"mongo') or
                                    param.startswith('--')]),

--- a/mtools/test/test_mlaunch_commandlines.py
+++ b/mtools/test/test_mlaunch_commandlines.py
@@ -49,15 +49,15 @@ class TestMLaunch(object):
     def cmdlist_filter(self, cmdlist):
         """Filter command lines to contain only [mongod|mongos] --parameter."""
         res = map(lambda cmd: set([param for param in cmd.split()
-                                   if param.startswith('mongo') or
+                                   if param.startswith('"mongo') or
                                    param.startswith('--')]),
-                  [cmd for cmd in cmdlist if cmd.startswith('mongod') and
+                  [cmd for cmd in cmdlist if cmd.startswith('"mongod') and
                    '--configsvr' in cmd] +
-                  [cmd for cmd in cmdlist if cmd.startswith('mongod') and
+                  [cmd for cmd in cmdlist if cmd.startswith('"mongod') and
                    '--shardsvr' in cmd] +
-                  [cmd for cmd in cmdlist if cmd.startswith('mongod') and
+                  [cmd for cmd in cmdlist if cmd.startswith('"mongod') and
                    '--configsvr' not in cmd and '--shardsvr' not in cmd] +
-                  [cmd for cmd in cmdlist if cmd.startswith('mongos')]
+                  [cmd for cmd in cmdlist if cmd.startswith('"mongos')]
                   )
         return(res)
 
@@ -79,7 +79,7 @@ class TestMLaunch(object):
         for observed, expected in zip(cmdset, cmdlisttest):
             # if mongod, account for some extra observed parameter
             # (e.g. wiredTigerCacheSizeGB)
-            if 'mongod' in expected:
+            if '"mongod"' in expected:
                 assert expected.issubset(observed)
                 assert expected.intersection(observed) == expected
             # if mongos, expected must match observed
@@ -117,7 +117,7 @@ class TestMLaunch(object):
         """mlaunch should start 1 node."""
         self.run_tool('init --single')
         cmdlist = [
-            set(['mongod', '--dbpath', '--logpath', '--port', '--fork'])
+            set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork'])
             ]
         self.cmdlist_assert(cmdlist)
 
@@ -125,7 +125,7 @@ class TestMLaunch(object):
         """mlaunch should start 1 node with specified storage."""
         self.run_tool('init --single --storageEngine mmapv1')
         cmdlist = [
-            set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+            set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                  '--storageEngine'])
             ]
         self.cmdlist_assert(cmdlist)
@@ -134,7 +134,7 @@ class TestMLaunch(object):
         """mlaunch should start 3 nodes replicaset."""
         self.run_tool('init --replicaset')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork'])] * 3
             )
         self.cmdlist_assert(cmdlist)
@@ -143,7 +143,7 @@ class TestMLaunch(object):
         """mlaunch should start 7 nodes replicaset."""
         self.run_tool('init --replicaset --nodes 7')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork'])] * 7
             )
         self.cmdlist_assert(cmdlist)
@@ -152,7 +152,7 @@ class TestMLaunch(object):
         """mlaunch should start 6 nodes + 1 arbiter replicaset."""
         self.run_tool('init --replicaset --nodes 6 --arbiter')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork'])] * 7
             )
         self.cmdlist_assert(cmdlist)
@@ -164,21 +164,21 @@ class TestMLaunch(object):
             self.raises_ioerror()
         elif LooseVersion(self.mongod_version) >= LooseVersion('3.3.0'):
             cmdlist = (
-                [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+                [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                       '--replSet', '--configsvr'])] +
-                [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+                [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                       '--shardsvr'])] * 2 +
-                [set(['mongos', '--logpath', '--port', '--configdb',
+                [set(['"mongos"', '--logpath', '--port', '--configdb',
                       '--fork'])]
                 )
             self.cmdlist_assert(cmdlist)
         else:
             cmdlist = (
-                [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+                [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                       '--configsvr'])] +
-                [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+                [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                       '--shardsvr'])] * 2 +
-                [set(['mongos', '--logpath', '--port', '--configdb',
+                [set(['"mongos"', '--logpath', '--port', '--configdb',
                       '--fork'])]
                 )
             self.cmdlist_assert(cmdlist)
@@ -191,11 +191,11 @@ class TestMLaunch(object):
         self.check_sccc()
         self.run_tool('init --sharded 2 --replicaset')
         cmdlist = (
-            [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+            [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                   '--configsvr'])] +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -207,11 +207,11 @@ class TestMLaunch(object):
         self.check_sccc()
         self.run_tool('init --sharded 2 --replicaset --config 2')
         cmdlist = (
-            [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+            [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                   '--configsvr'])] +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -223,11 +223,11 @@ class TestMLaunch(object):
         self.check_sccc()
         self.run_tool('init --sharded 2 --replicaset --config 3')
         cmdlist = (
-            [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+            [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                   '--configsvr'])] * 3 +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -239,11 +239,11 @@ class TestMLaunch(object):
         self.check_sccc()
         self.run_tool('init --sharded 2 --replicaset --config 4')
         cmdlist = (
-            [set(['mongod', '--dbpath', '--logpath', '--port', '--fork',
+            [set(['"mongod"', '--dbpath', '--logpath', '--port', '--fork',
                   '--configsvr'])] * 3 +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -255,11 +255,11 @@ class TestMLaunch(object):
         self.check_csrs()
         self.run_tool('init --sharded 2 --replicaset --config 1 --csrs')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--configsvr'])] +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -271,11 +271,11 @@ class TestMLaunch(object):
         self.check_csrs()
         self.run_tool('init --sharded 2 --replicaset --config 2 --csrs')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--configsvr'])] * 2 +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -287,11 +287,11 @@ class TestMLaunch(object):
         self.check_csrs()
         self.run_tool('init --sharded 2 --replicaset --config 3 --csrs')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--configsvr'])] * 3 +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -303,11 +303,11 @@ class TestMLaunch(object):
         self.check_csrs()
         self.run_tool('init --sharded 2 --replicaset --config 4 --csrs')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--configsvr'])] * 4 +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -317,11 +317,11 @@ class TestMLaunch(object):
         self.run_tool('init --sharded 2 --replicaset --csrs '
                       '--storageEngine mmapv1')
         cmdlist = (
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--configsvr'])] +
-            [set(['mongod', '--replSet', '--dbpath', '--logpath', '--port',
+            [set(['"mongod"', '--replSet', '--dbpath', '--logpath', '--port',
                   '--fork', '--storageEngine', '--shardsvr'])] * 6 +
-            [set(['mongos', '--logpath', '--port', '--configdb', '--fork'])]
+            [set(['"mongos"', '--logpath', '--port', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -330,11 +330,11 @@ class TestMLaunch(object):
         self.check_sccc()
         self.run_tool('init --sharded 1 --replicaset --nodes 1 --oplogSize 19')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork'])] +
-            [set(['mongod', '--port', '--replSet', '--shardsvr', '--logpath',
+            [set(['"mongod"', '--port', '--replSet', '--shardsvr', '--logpath',
                   '--dbpath', '--oplogSize', '--fork'])] +
-            [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
+            [set(['"mongos"', '--port', '--logpath', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -344,11 +344,11 @@ class TestMLaunch(object):
         self.run_tool('init --sharded 1 --replicaset --nodes 1 '
                       '--oplogSize 19 --csrs')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork', '--replSet'])] +
-            [set(['mongod', '--port', '--replSet', '--shardsvr', '--logpath',
+            [set(['"mongod"', '--port', '--replSet', '--shardsvr', '--logpath',
                   '--dbpath', '--oplogSize', '--fork'])] +
-            [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
+            [set(['"mongos"', '--port', '--logpath', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -357,11 +357,11 @@ class TestMLaunch(object):
         self.check_sccc()
         self.run_tool('init --sharded 2 --single --config 1 --mongos 2')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork'])] +
-            [set(['mongod', '--port', '--shardsvr', '--logpath', '--dbpath',
+            [set(['"mongod"', '--port', '--shardsvr', '--logpath', '--dbpath',
                   '--fork'])] * 2 +
-            [set(['mongos', '--port', '--logpath', '--configdb',
+            [set(['"mongos"', '--port', '--logpath', '--configdb',
                   '--fork'])] * 2
             )
         self.cmdlist_assert(cmdlist)
@@ -374,11 +374,11 @@ class TestMLaunch(object):
             self.raises_ioerror()
         else:
             cmdlist = (
-                [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+                [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                     '--fork', '--replSet'])] +
-                [set(['mongod', '--port', '--shardsvr', '--logpath', '--dbpath',
+                [set(['"mongod"', '--port', '--shardsvr', '--logpath', '--dbpath',
                     '--fork'])] * 2 +
-                [set(['mongos', '--port', '--logpath', '--configdb',
+                [set(['"mongos"', '--port', '--logpath', '--configdb',
                     '--fork'])] * 2
                 )
             self.cmdlist_assert(cmdlist)
@@ -388,11 +388,11 @@ class TestMLaunch(object):
         self.check_sccc()
         self.run_tool('init --sharded 2 --replicaset --config 3 --mongos 3')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork'])] * 3 +
-            [set(['mongod', '--port', '--shardsvr', '--logpath', '--dbpath',
+            [set(['"mongod"', '--port', '--shardsvr', '--logpath', '--dbpath',
                   '--fork', '--replSet'])] * 6 +
-            [set(['mongos', '--port', '--logpath', '--configdb',
+            [set(['"mongos"', '--port', '--logpath', '--configdb',
                   '--fork'])] * 3
             )
         self.cmdlist_assert(cmdlist)
@@ -403,11 +403,11 @@ class TestMLaunch(object):
         self.run_tool('init --sharded 2 --replicaset --config 3 '
                       '--mongos 3 --csrs')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork', '--replSet'])] * 3 +
-            [set(['mongod', '--port', '--shardsvr', '--logpath', '--dbpath',
+            [set(['"mongod"', '--port', '--shardsvr', '--logpath', '--dbpath',
                   '--fork', '--replSet'])] * 6 +
-            [set(['mongos', '--port', '--logpath', '--configdb',
+            [set(['"mongos"', '--port', '--logpath', '--configdb',
                   '--fork'])] * 3
             )
         self.cmdlist_assert(cmdlist)
@@ -424,11 +424,11 @@ class TestMLaunch(object):
             self.raises_ioerror()
         else:
             cmdlist = (
-                [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+                [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                     '--fork', '--replSet'])] +
-                [set(['mongod', '--port', '--logpath', '--dbpath', '--shardsvr',
+                [set(['"mongod"', '--port', '--logpath', '--dbpath', '--shardsvr',
                     '--fork'])] * 2 +
-                [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
+                [set(['"mongos"', '--port', '--logpath', '--configdb', '--fork'])]
                 )
             self.cmdlist_assert(cmdlist)
 
@@ -437,11 +437,11 @@ class TestMLaunch(object):
         self.check_3_4()
         self.run_tool('init --sharded 2 --replicaset')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork', '--replSet'])] +
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--shardsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--shardsvr',
                   '--fork', '--replSet'])] * 6 +
-            [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
+            [set(['"mongos"', '--port', '--logpath', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -453,11 +453,11 @@ class TestMLaunch(object):
         self.check_3_4()
         self.run_tool('init --sharded 2 --replicaset --nodes 7')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork', '--replSet'])] +
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--shardsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--shardsvr',
                   '--fork', '--replSet'])] * 14 +
-            [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
+            [set(['"mongos"', '--port', '--logpath', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -469,11 +469,11 @@ class TestMLaunch(object):
         self.check_3_4()
         self.run_tool('init --sharded 2 --replicaset --nodes 7 --config 5')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork', '--replSet'])] * 5 +
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--shardsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--shardsvr',
                   '--fork', '--replSet'])] * 14 +
-            [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
+            [set(['"mongos"', '--port', '--logpath', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 
@@ -486,13 +486,13 @@ class TestMLaunch(object):
         self.run_tool('init --sharded 2 --replicaset --nodes 2 --arbiter '
                       '--config 4 --mongos 2')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                   '--fork', '--replSet'])] * 4 +
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--shardsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--shardsvr',
                   '--fork', '--replSet'])] * 4 +
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--fork',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--fork',
                   '--replSet'])] * 2 +
-            [set(['mongos', '--port', '--logpath', '--configdb',
+            [set(['"mongos"', '--port', '--logpath', '--configdb',
                   '--fork'])] * 2
             )
         self.cmdlist_assert(cmdlist)
@@ -504,11 +504,11 @@ class TestMLaunch(object):
         self.check_3_4()
         self.run_tool('init --sharded 2 --replicaset --storageEngine mmapv1')
         cmdlist = (
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--configsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--configsvr',
                 '--fork', '--replSet'])] +
-            [set(['mongod', '--port', '--logpath', '--dbpath', '--shardsvr',
+            [set(['"mongod"', '--port', '--logpath', '--dbpath', '--shardsvr',
                 '--fork', '--storageEngine'])] * 6 +
-            [set(['mongos', '--port', '--logpath', '--configdb', '--fork'])]
+            [set(['"mongos"', '--port', '--logpath', '--configdb', '--fork'])]
             )
         self.cmdlist_assert(cmdlist)
 


### PR DESCRIPTION
Fixes #578 