### PR TITLE
Fix #596: mlaunch: KeyError: 'port' with Python 3.6.5

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1343,19 +1343,6 @@ class MLaunchTool(BaseCmdLineTool):
 
     # --- below here are internal helper methods, do not call externally ---
 
-    def _convert_u2b(self, obj):
-        """Helper method to convert unicode back to plain text."""
-        if isinstance(obj, dict):
-            return(dict([(self._convert_u2b(key),
-                          self._convert_u2b(value))
-                         for key, value in six.iteritems(obj)]))
-        elif isinstance(obj, list):
-            return [self._convert_u2b(element) for element in obj]
-        elif isinstance(obj, six.text_type):
-            return obj.encode('utf-8')
-        else:
-            return obj
-
     def _load_parameters(self):
         """
         Load the .mlaunch_startup file that exists in each datadir.

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1368,7 +1368,7 @@ class MLaunchTool(BaseCmdLineTool):
         if not os.path.exists(startup_file):
             return False
 
-        in_dict = self._convert_u2b(json.load(open(startup_file, 'rb')))
+        in_dict = json.load(open(startup_file, 'rb'))
 
         # handle legacy version without versioned protocol
         if 'protocol_version' not in in_dict:

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1687,7 +1687,7 @@ class MLaunchTool(BaseCmdLineTool):
                 raise e
 
     def _get_processes(self):
-        all_ports = self.get_tagged('running')
+        all_ports = self.get_tagged(['running'])
 
         process_dict = {}
 

--- a/mtools/test/test_mlaunch.py
+++ b/mtools/test/test_mlaunch.py
@@ -304,8 +304,7 @@ class TestMLaunch(object):
         assert os.path.isfile(startup_file)
 
         # compare content of startup file with tool.args
-        file_contents = self.tool._convert_u2b(json.load(open(startup_file,
-                                                              'rb')))
+        file_contents = json.load(open(startup_file, 'rb'))
         assert file_contents['parsed_args'] == self.tool.args
         assert file_contents['unknown_args'] == self.tool.unknown_args
 


### PR DESCRIPTION
The `_convert_u2b()` method no longer appears to be required with the recent updates for Py2/3 support. This causes KeyErrors in Python 3.6.5 and removal appears to keep both py27 and py36 happy.