### PR TITLE
Report actual error when import fails in mplotqueries.

### DIFF
--- a/mtools/mplotqueries/mplotqueries.py
+++ b/mtools/mplotqueries/mplotqueries.py
@@ -18,13 +18,13 @@ try:
     from matplotlib.dates import AutoDateFormatter, date2num, AutoDateLocator
     from matplotlib import __version__ as mpl_version
     import mtools.mplotqueries.plottypes as plottypes
-except ImportError:
+except ImportError as e:
     raise ImportError("Can't import matplotlib. See "
                       "github.com/rueckstiess/mtools/blob/master/INSTALL.md "
                       "for instructions how to install matplotlib or try "
                       "mlogvis instead, which is a simplified version of "
                       "mplotqueries that visualizes the logfile in a "
-                      "web browser.")
+                      "web browser. Error: " + str(e))
 
 
 class MPlotQueriesTool(LogFileTool):


### PR DESCRIPTION
## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->

Before:

<pre>
% ~/.local/bin/mplotqueries ./mongod.log
Traceback (most recent call last):
  File "/home/w/.local/bin/mplotqueries", line 7, in <module>
    from mtools.mplotqueries.mplotqueries import main
  File "/home/w/.local/lib/python2.7/site-packages/mtools/mplotqueries/mplotqueries.py", line 22, in <module>
    raise ImportError("Can't import matplotlib. See "
ImportError: Can't import matplotlib. See github.com/rueckstiess/mtools/blob/master/INSTALL.md for instructions how to install matplotlib or try mlogvis instead, which is a simplified version of mplotqueries that visualizes the logfile in a web browser.
</pre>

OK, let's see what the deal is with matplotlib:

<pre>
averagest% python
Python 2.7.15 (default, May  1 2018, 05:55:50)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import matplotlib
>>> matplotlib
&lt;module 'matplotlib' from '/home/w/.local/lib/python2.7/site-packages/matplotlib/__init__.pyc'>
>>>
</pre>

Hmm, it seems fine. What needs to be done?

After:

<pre>
% ~/.local/bin/mplotqueries ./mongod.log
Traceback (most recent call last):
  File "/home/w/.local/bin/mplotqueries", line 7, in <module>
    from mtools.mplotqueries.mplotqueries import main
  File "/home/w/.local/lib/python2.7/site-packages/mtools/mplotqueries/mplotqueries.py", line 27, in <module>
    "web browser. Error: " + str(e))
ImportError: Can't import matplotlib. See github.com/rueckstiess/mtools/blob/master/INSTALL.md for instructions how to install matplotlib or try mlogvis instead, which is a simplified version of mplotqueries that visualizes the logfile in a web browser. Error: No module named _tkinter, please install the python-tk package
</pre>

Thanks, helpful error message!

Fixes #620

<!--
 To make it easier to review Pull Requests, please provide the details below.
-->


## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->

Attempt to use mplotqueries on a minimal Debian installation after installing mtools following installation instructions.

O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | Debian Testing
| macOS            | 
| Windows          |
