### PR TITLE
Enable passing --nopreallocj to mongod

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -146,13 +146,10 @@ def shutdown_host(port, username=None, password=None, authdb=None):
 
 
 class MLaunchTool(BaseCmdLineTool):
-
     UNDOCUMENTED_MONGOD_ARGS = ['--nopreallocj']
-    UNDOCUMENTED_MONGOS_ARGS = []
 
     def __init__(self, test=False):
         BaseCmdLineTool.__init__(self)
-        self.hostname = socket.gethostname()
 
         # arguments
         self.args = None
@@ -1491,8 +1488,6 @@ class MLaunchTool(BaseCmdLineTool):
                 if arg in accepted_arguments or re.match(r'-v+', arg):
                     result.append(arg)
                 elif binary.endswith('mongod') and arg in self.UNDOCUMENTED_MONGOD_ARGS:
-                    result.append(arg)
-                elif binary.endswith('mongos') and arg in self.UNDOCUMENTED_MONGOS_ARGS:
                     result.append(arg)
                 elif self.ignored_arguments.get(binary + arg) is None:
                     # warn once for each combination of binary and unknown arg

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1668,8 +1668,8 @@ class MLaunchTool(BaseCmdLineTool):
 
         try:
             con[database].add_user(name, password=password, roles=roles, **opts)
-        except OperationFailure:
-            pass
+        except OperationFailure as e:
+            raise e
         except TypeError as e:
             if pymongo_version < (2, 5, 0):
                 con[database].add_user(name, password=password, **opts)


### PR DESCRIPTION
This is one of a number of patches Cloud has been using in a forked version of mtools. 
We would like to merge these & start using master instead. 

This PR: 
- enable passing --nopreallocj to mongod
- raise if user addition fails. 