### PR TITLE
Add users to all shards in sharded cluster

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -745,6 +745,14 @@ class MLaunchTool(BaseCmdLineTool):
                            database=self.args['auth_db'],
                            roles=self.args['auth_roles'])
 
+            if self.args['sharded']:
+                for shard in shard_names:
+                    members = sorted(self.get_tagged([shard]))
+                    if self.args['verbose']:
+                        print("adding users to %s" % shard)
+                    self._add_user(members[0], name=self.args['username'], password=self.args['password'],
+                                  database=self.args['auth_db'], roles=self.args['auth_roles'])
+
             if self.args['verbose']:
                 print("added user %s on %s database" % (self.args['username'],
                                                         self.args['auth_db']))


### PR DESCRIPTION
This is one of a number of patches Cloud has been using in a forked version of mtools.
We would like to merge these & start using master instead.

