### PR TITLE
Fixed early return in mlaunch _start_on_ports()

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1613,7 +1613,6 @@ class MLaunchTool(BaseCmdLineTool):
                     print("launching: %s" % command_str)
                 else:
                     print("launching: %s on port %s" % (binary, port))
-                return ret
 
             except subprocess.CalledProcessError as e:
                 print(e.output)


### PR DESCRIPTION
mlaunch `_start_on_ports()` function contains an early return inside a `for` loop. This makes mlaunch unable to start multiple nodes, since it will return after it successfully start one node.