### PR TITLE
Replace characters that can't be decoded with '?'

### DIFF
--- a/mtools/util/logfile.py
+++ b/mtools/util/logfile.py
@@ -204,7 +204,7 @@ class LogFile(InputSource):
         # use readline here because next() iterator uses internal readahead
         # buffer so seek position is wrong
         line = self.filehandle.readline()
-        line = line.decode('utf-8')
+        line = line.decode('utf-8', 'replace')
         if line == '':
             raise StopIteration
         line = line.rstrip('\n')
@@ -272,7 +272,7 @@ class LogFile(InputSource):
 
         ln = 0
         for ln, line in enumerate(self.filehandle):
-            line = line.decode("utf-8") 
+            line = line.decode("utf-8", "replace")
             if (self._has_level is None and
                     line[28:31].strip() in LogEvent.log_levels and
                     line[31:39].strip() in LogEvent.log_components):
@@ -481,7 +481,7 @@ class LogFile(InputSource):
                              % self.filehandle.name)
         else:
             self.prev_pos = curr_pos
-        buff = buff.decode("utf-8")
+        buff = buff.decode("utf-8", "replace")
         newline_pos = buff.rfind('\n')
         if prev:
             newline_pos = buff[:newline_pos].rfind('\n')


### PR DESCRIPTION
## Description of changes
When processing some logs from our mongo 3.4.15 server we ran into this decoding issue:

```python
Traceback (most recent call last):
  File "testenv/bin/mloginfo", line 11, in <module>
    sys.exit(main())
  File "/Users/matthewthompson/testenv/lib/python2.7/site-packages/mtools/mloginfo/mloginfo.py", line 95, in main
    tool.run()
  File "/Users/matthewthompson/testenv/lib/python2.7/site-packages/mtools/mloginfo/mloginfo.py", line 58, in run
    if self.logfile.hostname else "unknown"))
  File "/Users/matthewthompson/testenv/lib/python2.7/site-packages/mtools/util/logfile.py", line 154, in hostname
    self._iterate_lines()
  File "/Users/matthewthompson/testenv/lib/python2.7/site-packages/mtools/util/logfile.py", line 275, in _iterate_lines
    line = line.decode("utf-8-sig")
  File "/Users/matthewthompson/testenv/lib/python2.7/encodings/utf_8_sig.py", line 22, in decode
    (output, consumed) = codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xe2 in position 386: invalid continuation byte
```
I was able to fix it by just decoding with the replace fallback so the bad characters end up as `'?'` instead.

## Testing
Attached is a redacted sample log to illustrate the problem. Run like this: `mloginfo --queries test3.log`
[test3.log](https://github.com/rueckstiess/mtools/files/2128401/test3.log)

O/S testing:

| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            | Python 2.7.14, OSX 10.13.5
| Windows          |
