### PR TITLE
Escape dollar signs in mplotqueries legend. Fixes #613

### DIFF
--- a/mtools/mplotqueries/mplotqueries.py
+++ b/mtools/mplotqueries/mplotqueries.py
@@ -645,17 +645,13 @@ class MPlotQueriesTool(LogFileTool):
 
         handles, labels = axis.get_legend_handles_labels()
         if len(labels) > 0:
-            # escape dollar signs in legend labels
-            labels = [x.replace('$', '\$') for x in labels]
             # only change fontsize if supported
             major, minor, _ = mpl_version.split('.')
             if (int(major), int(minor)) >= (1, 3):
-                self.legend = axis.legend(labels=labels,
-                                          loc='upper left', frameon=False,
+                self.legend = axis.legend(loc='upper left', frameon=False,
                                           numpoints=1, fontsize=9)
             else:
-                self.legend = axis.legend(labels=labels,
-                                          loc='upper left', frameon=False,
+                self.legend = axis.legend(loc='upper left', frameon=False,
                                           numpoints=1)
 
         if self.args['type'] == 'scatter':

--- a/mtools/mplotqueries/mplotqueries.py
+++ b/mtools/mplotqueries/mplotqueries.py
@@ -645,13 +645,17 @@ class MPlotQueriesTool(LogFileTool):
 
         handles, labels = axis.get_legend_handles_labels()
         if len(labels) > 0:
+            # escape dollar signs in legend labels
+            labels = [x.replace('$', '\$') for x in labels]
             # only change fontsize if supported
             major, minor, _ = mpl_version.split('.')
             if (int(major), int(minor)) >= (1, 3):
-                self.legend = axis.legend(loc='upper left', frameon=False,
+                self.legend = axis.legend(labels=labels,
+                                          loc='upper left', frameon=False,
                                           numpoints=1, fontsize=9)
             else:
-                self.legend = axis.legend(loc='upper left', frameon=False,
+                self.legend = axis.legend(labels=labels,
+                                          loc='upper left', frameon=False,
                                           numpoints=1)
 
         if self.args['type'] == 'scatter':

--- a/mtools/mplotqueries/plottypes/scatter_type.py
+++ b/mtools/mplotqueries/plottypes/scatter_type.py
@@ -74,9 +74,10 @@ class ScatterPlotType(BasePlotType):
         if self.logscale:
             axis.semilogy()
 
+        group_label = group.replace('$', '\$')
         artist = axis.plot_date(x, y, color=color, markeredgecolor='k',
                                 marker=marker, alpha=0.8,
-                                markersize=7, picker=5, label=group)[0]
+                                markersize=7, picker=5, label=group_label)[0]
         # add meta-data for picking
         artist._mt_plot_type = self
         artist._mt_group = group


### PR DESCRIPTION
In `mplotqueries` legend, if any text contains two dollar signs, it will be interpreted by matplotlib as a mathtext. This resulted in unexpected formatting.

Currently this is the default behaviour of matplotlib and cannot be disabled: https://github.com/matplotlib/matplotlib/issues/4938

The current solution is to escape the dollar signs in the legend labels to disable unexpected mathtext formatting. This should fix #613 