### PR TITLE
Ensure sys.stdout is unicode

### DIFF
--- a/mtools/util/cmdlinetool.py
+++ b/mtools/util/cmdlinetool.py
@@ -2,6 +2,7 @@
 """Command line tool utility."""
 
 import argparse
+import codecs
 import datetime
 import os
 import re
@@ -97,6 +98,14 @@ class BaseCmdLineTool(object):
                                     default=False,
                                     help='disables progress bar')
         self.is_stdin = not sys.stdin.isatty()
+
+        # Set stdout encoding to utf-8 if not set
+        # Need to check for nose because it monkey patches sys.stdout:
+        #     https://github.com/nose-devs/nose/issues/1065
+        if ('nose' not in sys.modules.keys()
+                and hasattr(sys.stdout, 'encoding')
+                and not sys.stdout.encoding):
+            sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
     def run(self, arguments=None, get_unknowns=False):
         """


### PR DESCRIPTION
Due to Python 2.7's magic, redirecting output to a file or anything other than a terminal will not honour the host's locale setting. This means that output redirection will default to ASCII, which will crash e.g. `mlogfilter` when unicode characters are present in the log file. This was the cause of #643.

Since MongoDB log files are `utf-8` by default, we think it's a better solution to enforce this encoding on `sys.stdout` instead of relying on the user remembering to set `PYTHONIOENCODING`.

To make things more interesting, nose monkey patches `sys.stdout` (https://github.com/nose-devs/nose/issues/1065). This necessitates detecting if nose is being used, otherwise tests will fail.

Python 3 does not appear to have this issue. Redirects are so far safer compared to 2.7.