### PR TITLE
Fix #662: mlaunch should specify appname

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -64,6 +64,9 @@ class MongoConnection(Connection):
             if 'serverSelectionTimeoutMS' in kwargs:
                 kwargs.remove('serverSelectionTimeoutMS')
 
+        # Set client application name for MongoDB 3.4+ servers
+        kwargs['appName'] = 'mlaunch v{0}'.format(__version__)
+
         Connection.__init__(self, *args, **kwargs)
 
 


### PR DESCRIPTION
## Description of changes

Set PyMongo client appname to `mlaunch v#.##`

## Testing

Verified that application.name appears in 3.4+ logs, eg:

    2018-09-03T15:55:04.917+1000 I NETWORK  [conn1] received client metadata from 127.0.0.1:56334 conn1: { driver: { name: "PyMongo", version: "3.6.0" }, os: { type: "Darwin", name: "Darwin", architecture: "x86_64", version: "10.13.6" }, platform: "CPython 2.7.14.final.0", application: { name: "mlaunch v1.5.2-dev" } }