### PR TITLE
Only use roles variable instead of args once it's set up

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -748,8 +748,7 @@ class MLaunchTool(BaseCmdLineTool):
                         found_cluster_admin = True
             else:
                 roles = self.args['auth_roles']
-
-            found_cluster_admin = "clusterAdmin" in self.args['auth_roles']
+                found_cluster_admin = "clusterAdmin" in roles
 
             if not found_cluster_admin:
                 warnings.warn("the stop command will not work with auth "
@@ -770,7 +769,7 @@ class MLaunchTool(BaseCmdLineTool):
                                    name=self.args['username'],
                                    password=self.args['password'],
                                    database=self.args['auth_db'],
-                                   roles=self.args['auth_roles'])
+                                   roles=roles)
 
             if self.args['verbose']:
                 print("added user %s on %s database" % (self.args['username'],


### PR DESCRIPTION
<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
Resolves #661 by using the `roles` variable once it's been constructed in order to handle the case where roles are supplied on the command line as documents as opposed to just the role name string. This is important when `--auth-db` is going to be something other than admin, like `$external`.

## Testing
Sample command which did not work before because role doc was being passed directly as a role name:
```
mlaunch init --sharded do re me --config 3 --mongos 2 --replicaset --nodes 3 --oplogSize 100 --dir /data/db/shtest/ --port 28017 --binarypath /usr/local/mongodb/bin/ --noprealloc --nopreallocj --smallfiles --hostname gmbp.local \
--auth --username admin --password mongodb --auth-db admin \
--auth-role-docs \
--auth-roles "{ \"role\": \"dbAdminAnyDatabase\", \"db\": \"admin\" }" "{ \"role\": \"readWriteAnyDatabase\", \"db\": \"admin\" }" "{ \"role\": \"userAdminAnyDatabase\", \"db\": \"admin\" }" "{ \"role\": \"clusterAdmin\", \"db\": \"admin\" }"
```

O/S testing:

| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            | 10.13.6 
| Windows          | 
