### PR TITLE
mlogexcel tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,13 @@ pip-log.txt
 
 # Doc build files
 _build
+
+# vim swap files
+*.swp
+
+# Virtualenv related directories
+venv
+
+# Local output files
+stdin.html
+stdin.xlsx

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,7 @@ utility to quickly set up complex MongoDB test environments on a local machine.
 
    install.rst
    mlaunch.rst
+   mlogexcel.rst
    mlogfilter.rst
    mloginfo.rst
    mlogvis.rst
@@ -25,6 +26,9 @@ What's in the box?
 ~~~~~~~~~~~~~~~~~~
 
 The following tools are in the mtools collection:
+
+:ref:`mlogexcel`
+   writes parsed log messages to an Excel .xslx file (requires openpyxl)
 
 :ref:`mlogfilter`
    slices log files by time, merges log files, filters slow queries, finds

--- a/doc/mlogexcel.rst
+++ b/doc/mlogexcel.rst
@@ -1,0 +1,47 @@
+.. _mlogexcel:
+
+=========
+mlogexcel
+=========
+
+**mlogexcel** is a script to parse log files and dump them into an Excel file.
+The log message fields are organized as columns.  The Excel file can be used
+later for analysis or simply more convenient visual inspection.
+
+
+Usage
+~~~~~
+
+.. code-block:: bash
+
+   mlogexcel [-h] [--version] logfile
+             [-o|--out] [--pattern]
+
+**mlogexcel** can also be used with shell pipe syntax:
+
+.. code-block:: bash
+
+   mlogfilter logfile [parameters] | mlogexcel
+
+
+General Parameters
+~~~~~~~~~~~~~~~~~~
+
+Help
+----
+``-h, --help``
+   shows the help text and exits.
+
+Version
+-------
+``--version``
+   shows the version number and exits.
+
+Output
+---------
+``-o, --out``
+   output filename.  Default is <original logfile>.xlsx
+
+``--actual``
+   output the original JSON instead of patterns for query text, sort keys,
+   and planSummary

--- a/mtools/mlogexcel/mlogexcel.py
+++ b/mtools/mlogexcel/mlogexcel.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+import os
+import sys
+
+from openpyxl import Workbook
+from openpyxl.styles import Font
+
+from mtools.util.cmdlinetool import LogFileTool
+
+
+class MLogExcelTool(LogFileTool):
+    def __init__(self):
+        """Constructor: add description to argparser."""
+        LogFileTool.__init__(self, multiple_logfiles=False,
+                             stdin_allowed=True)
+
+        self.argparser.description = ('Extracts fields from log messages and '
+                                      'writes them to an Excel 2010 xlsx '
+                                      'file.')
+        self.argparser.add_argument('--out', '-o', action='store',
+                                    default=None,
+                                    help=('filename to output. Default is '
+                                          '<original logfile>.xlsx'))
+        self.argparser.add_argument('--actual', action='store_true',
+                                    help=('show the actual JSON (instead of '
+                                          'patterns) for queries, sort '
+                                          'keys, and planSummary.'))
+
+    def run(self, arguments=None):
+        """Copy log messages to an Excel file."""
+        LogFileTool.run(self, arguments)
+
+        # change stdin logfile name and remove the < >
+        logname = self.args['logfile'].name
+        if logname == '<stdin>':
+            logname = 'stdin'
+
+        if self.args['out'] is not None:
+            outputname = self.args['out']
+        else:
+            outputname = logname + '.xlsx'
+
+        if not os.access(os.path.dirname(os.path.realpath(outputname)),
+                         os.W_OK):
+            print('Cannot write to file: %s' % outputname)
+            sys.exit(1)
+
+        wb = Workbook()
+        ops_ws = wb.active
+        ops_ws.title = 'Operations'
+        info_ws = wb.create_sheet('Information')
+
+        ops_ws.column_dimensions['B'].width = 20
+        ops_ws.column_dimensions['C'].width = 12
+        ops_ws.column_dimensions['E'].width = 20
+        ops_ws.column_dimensions['F'].width = 15
+        ops_ws.column_dimensions['G'].width = 10
+        ops_ws.column_dimensions['H'].width = 30
+        ops_ws.column_dimensions['I'].width = 30
+        ops_ws.column_dimensions['J'].width = 30
+        ops_ws.column_dimensions['K'].width = 10
+        ops_ws.column_dimensions['L'].width = 10
+        ops_ws.column_dimensions['M'].width = 10
+        ops_ws.column_dimensions['N'].width = 10
+        ops_ws.column_dimensions['O'].width = 10
+
+        info_ws.column_dimensions['B'].width = 20
+        info_ws.column_dimensions['C'].width = 12
+
+        ops_ws.append([
+            'lineno',
+            'datetime',
+            'thread',
+            'duration',
+            'namespace',
+            'command',
+            'operation',
+            'pattern' if not self.args['actual'] else 'query',
+            'sort_pattern' if not self.args['actual'] else 'sort',
+            'planSummary',
+            'nscanned',
+            'ntoreturn',
+            'nreturned',
+            'ninserted',
+            'nupdated',
+        ])
+
+        info_ws.append([
+            'lineno',
+            'datetime',
+            'thread',
+            'message',
+        ])
+        ops_ws.freeze_panes = 'A2'
+        info_ws.freeze_panes = 'A2'
+
+        ops_row = 1
+
+        for lineno, logevent in enumerate(self.args['logfile'], 1):
+            if logevent.operation:
+                # need to track the actual row number on the sheet in order to
+                # apply cell format changes
+                ops_row += 1
+
+                ops_ws.append([
+                    lineno,
+                    logevent.datetime,
+                    logevent.thread,
+                    logevent.duration,
+                    logevent.namespace,
+                    logevent.command,
+                    logevent.operation,
+                    (logevent.pattern if not self.args['actual'] else
+                        logevent.actual_query),
+                    (logevent.sort_pattern if not self.args['actual'] else
+                        logevent.actual_sort),
+                    (logevent.planSummary if not self.args['actual'] else
+                        logevent.actualPlanSummary),
+                    logevent.nscanned,
+                    logevent.ntoreturn,
+                    logevent.nreturned,
+                    logevent.ninserted,
+                    logevent.nupdated
+                ])
+
+                # add 'ms' suffix to cell format for duration
+                coord = 'D%d' % ops_row
+                ops_ws[coord].number_format = '0" ms"'
+            else:
+                msg = logevent.line_str[logevent.line_str.index(']') + 2:]
+                info_ws.append([
+                    lineno,
+                    logevent.datetime,
+                    logevent.thread,
+                    msg,
+                ])
+
+        # apply formatting to header cells
+        for col in [chr(num) for num in range(ord('A'), ord('O') + 1)]:
+            coord = '%s1' % col
+            ops_ws[coord].font = Font(bold=True, underline='single')
+        for col in [chr(num) for num in range(ord('A'), ord('D') + 1)]:
+            coord = '%s1' % col
+            info_ws[coord].font = Font(bold=True, underline='single')
+
+        wb.save(outputname)
+
+
+def main():
+    tool = MLogExcelTool()
+    tool.run()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/mtools/test/test_util_logevent.py
+++ b/mtools/test/test_util_logevent.py
@@ -138,7 +138,6 @@ def test_logevent_datetime_parsing():
 
 
 def test_logevent_pattern_parsing():
-
     le = LogEvent(line_pattern_26_a)
     assert(le.pattern) == '{"a": 1}'
 
@@ -149,8 +148,18 @@ def test_logevent_pattern_parsing():
     assert(le.pattern) == '{"a": 1}'
 
 
-def test_logevent_command_parsing():
+def test_logevent_actual_query_parsing():
+    le = LogEvent(line_pattern_26_a)
+    assert(le.actual_query) == '{ a: 1.0 }'
 
+    le = LogEvent(line_pattern_26_b)
+    assert(le.actual_query) == '{ a: 1.0 }'
+
+    le = LogEvent(line_pattern_26_c)
+    assert(le.actual_query) == '{ a: 1.0 }'
+
+
+def test_logevent_command_parsing():
     le = LogEvent(line_command_26_a)
     assert(le.command) == 'replsetgetstatus'
 
@@ -162,7 +171,6 @@ def test_logevent_command_parsing():
 
 
 def test_logevent_sort_pattern_parsing():
-
     le = LogEvent(line_pattern_26_a)
     assert(le.sort_pattern) is None
 
@@ -171,6 +179,17 @@ def test_logevent_sort_pattern_parsing():
 
     le = LogEvent(line_pattern_26_c)
     assert(le.sort_pattern) == '{"b": 1}'
+
+
+def test_logevent_actual_sort_parsing():
+    le = LogEvent(line_pattern_26_a)
+    assert(le.actual_sort) is None
+
+    le = LogEvent(line_pattern_26_b)
+    assert(le.actual_sort) == '{ b: 1.0 }'
+
+    le = LogEvent(line_pattern_26_c)
+    assert(le.actual_sort) == '{ b: 1.0 }'
 
 
 def test_logevent_profile_pattern_parsing():
@@ -214,6 +233,17 @@ def test_logevent_extract_planSummary():
     le = LogEvent(line_26_planSummary)
     assert(le.planSummary == "IXSCAN")
 
+    le = LogEvent(line_pattern_26_a)
+    assert(le.planSummary == "EOF")
+
+
+def test_logevent_extract_actualPlanSummary():
+    le = LogEvent(line_26_planSummary)
+    assert(le.actualPlanSummary == "IXSCAN { cid: 1 }")
+
+    le = LogEvent(line_pattern_26_a)
+    assert(le.actualPlanSummary == "EOF")
+
 
 def test_logevent_value_extraction():
     """ Check for correct value extraction of all fields. """
@@ -228,6 +258,7 @@ def test_logevent_value_extraction():
     assert(le.ntoreturn == 0)
     assert(le.nreturned == 13551)
     assert(le.pattern == '{"ts": 1}')
+
 
 def test_logevent_non_log_line():
     """ Check that LogEvent correctly ignores non log lines"""
@@ -253,10 +284,12 @@ def test_logevent_non_log_line():
     assert(le.nreturned == None)
     assert(le.pattern == None)
 
+
 def test_logevent_new_oplog_query():
     """ Check that LogEvent correctly ignores new oplog query for duration extraction """
     le = LogEvent(line_new_oplog_query)
     assert(le.duration == None)
+
 
 def test_logevent_lazy_evaluation():
     """ Check that all LogEvent variables are evaluated lazily. """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ ordereddict==1.1
 python-dateutil==2.7
 matplotlib==1.4.3
 numpy==1.14.5
+openpyxl==2.5.4
 pymongo==3.6.1
 psutil==5.4.2

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ try:
     extras_requires = {
         "all": ['matplotlib==1.4.3', 'numpy==1.14.5', 'pymongo==3.6.1', 'psutil==5.4.2'],
         "mlaunch": ['pymongo==3.6.1', 'psutil==5.4.2'],
+        "mlogexcel": ['openpyxl==2.5.4'],
         "mlogfilter": [],
         "mloginfo": ['numpy==1.14.5'],
         "mlogvis": [],
@@ -44,6 +45,7 @@ except ImportError:
     # find_packages not available in distutils, manually define packaging
     packages = ['mtools',
                 'mtools.mlaunch',
+                'mtools.mlogexcel',
                 'mtools.mlogfilter',
                 'mtools.mloginfo',
                 'mtools.mlogvis',
@@ -84,6 +86,7 @@ setup(
         "console_scripts": [
             "mgenerate=mtools.mgenerate.mgenerate:main",
             "mlaunch=mtools.mlaunch.mlaunch:main",
+            "mlogexcel=mtools.mlogexcel.mlogexcel:main",
             "mlogfilter=mtools.mlogfilter.mlogfilter:main",
             "mloginfo=mtools.mloginfo.mloginfo:main",
             "mlogvis=mtools.mlogvis.mlogvis:main",


### PR DESCRIPTION
<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
This change adds a new tool called `mlogexcel` which simply writes the log lines to an .xlsx file with the message fields extracted into columns. Users can then use tools within Excel to filter/sort/extract/highlight log events as needed. The tool also works on log lines piped to stdin from `mlogfilter`.

This also adds new properties to LogEvent to support listing actual JSON as an alternative to the summarized JSON. You can run `mlogexcel --actual` to get the actual JSON, in case the actual values found in the log are significant to you. To be more consistent with the other tools, `mlogexcel` still outputs summarized JSON by default if `--actual` is not passed. Unit tests were added to cover the changes in LogEvent.

For #671 

## Testing
Tested on various log files from MongoDB 3.4 production and test environments. The largest log file tested was slightly under 2GB.

O/S testing:
Fedora 25 (Python 3.5 and 2.7)