### PR TITLE
Fix #670: --wiredTigerCacheSizeGB warning for sharded cluster

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -146,6 +146,7 @@ def shutdown_host(port, username=None, password=None, authdb=None):
 
 class MLaunchTool(BaseCmdLineTool):
     UNDOCUMENTED_MONGOD_ARGS = ['--nopreallocj']
+    UNSUPPORTED_MONGOS_ARGS = ['--wiredTigerCacheSizeGB']
 
     def __init__(self, test=False):
         BaseCmdLineTool.__init__(self)
@@ -1506,7 +1507,7 @@ class MLaunchTool(BaseCmdLineTool):
 
         # add undocumented options
         accepted_arguments.append('--setParameter')
-        if binary == "mongod":
+        if binary.endswith('mongod'):
             accepted_arguments.append('--wiredTigerEngineConfigString')
 
         # filter valid arguments
@@ -1523,8 +1524,10 @@ class MLaunchTool(BaseCmdLineTool):
                 elif self.ignored_arguments.get(binary + arg) is None:
                     # warn once for each combination of binary and unknown arg
                     self.ignored_arguments[binary + arg] = True
-                    print("warning: ignoring unknown argument %s for %s" %
-                          (arg, binary))
+                    if not (binary.endswith("mongos") and
+                            arg in self.UNSUPPORTED_MONGOS_ARGS):
+                        print("warning: ignoring unknown argument %s for %s" %
+                              (arg, binary))
             elif i > 0 and arguments[i - 1] in result:
                 # if it doesn't start with a '-', it could be the value of
                 # the last argument, e.g. `--slowms 1000`


### PR DESCRIPTION
## Description of changes

 - Don't warn about `--wiredTigerCacheSizeGB` being an unknown argument for `mongos`
 - Fix a comparison of `binary` value (required when `binarypath` is prepended to `binary`)