### PR TITLE
Improve json2pattern handling of arrays

### DIFF
--- a/mtools/util/pattern.py
+++ b/mtools/util/pattern.py
@@ -81,7 +81,7 @@ def json2pattern(s):
     # handle shell values that are not valid JSON
     s = shell2json(s)
     # convert to 1 where possible, to get rid of things like new Date(...)
-    s, n = re.subn(r'([:,\[])\s*([^{}\[\]"]+?)\s*([,}\]])', '\\1 1 \\3', s)
+    s, n = re.subn(r'([:,\[])\s*([^{}\[\]",]+?)\s*(?=[,}\]])', '\\1 1 ', s)
     # now convert to dictionary, converting unicode to ascii
     try:
         doc = json.loads(s, object_hook=_decode_pattern_dict)
@@ -119,4 +119,7 @@ if __name__ == '__main__':
 
     s = ('{ _id: ObjectId(\'528556616dde23324f233168\'), '
          'config: { _id: 2, host: "localhost:27017" }, ns: "local.oplog.rs" }')
+    print(json2pattern(s))
+
+    s = '{ $geometry: { type: "Point", coordinates: [ 174.78, -41.29 ] }, $maxDistance: 50000 }'
     print(json2pattern(s))


### PR DESCRIPTION
<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->

Some of our queries were not correctly converted to patterns, and so were not grouped correctly. The issue appeared to be with values in arrays, as the existing pattern matched the comma that separated values, and therefore in a two-component array only the first component was matched.

e.g. 
```json
{ $geometry: { type: "Point", coordinates: [ 174.78, -41.29 ] }, $maxDistance: 50000 }
```


## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->

I have added a "test" for the example above to the bottom of `pattern.py` matching the other examples that are in the __main__ of that file.
