### PR TITLE
Include queries without durations in the query count

### DIFF
--- a/mtools/mloginfo/sections/query_section.py
+++ b/mtools/mloginfo/sections/query_section.py
@@ -102,12 +102,13 @@ class QuerySection(BaseSection):
 
             group_events = [le.duration for le in grouping[g]
                             if le.duration is not None]
+            group_events_all = [le.duration for le in grouping[g]]
 
             stats = OrderedDict()
             stats['namespace'] = namespace
             stats['operation'] = op
             stats['pattern'] = pattern
-            stats['count'] = len(group_events)
+            stats['count'] = len(group_events_all)
             stats['min'] = min(group_events) if group_events else '-'
             stats['max'] = max(group_events) if group_events else '-'
             stats['mean'] = 0


### PR DESCRIPTION
<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->

Some of our queries don't have durations in the logs because compose.com truncated the log lines at 1100 characters. This change means that `mloginfo` still shows count statistics for these lines even though no durations were present. The other statistics that are related to the durations are still represented as `-`s. Better than nothing for us!


## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->

Remove the duration from the query log lines and run `mloginfo` across it. Now you'll get the count and no other stats.

We have tested on macOS.