### PR TITLE
Fix #694: Remove support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
 install: pip install tox
 script:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@ Installation Instructions for mtools
 
 ### Python
 
-You need to have Python 2.7.x installed in order to use mtools. Other versions of Python are not currently supported.
+You need to have Python 3.6.x installed in order to use mtools. Other versions of Python are not currently supported.
 
 To check your Python version, run `python --version` on the command line.
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 mtools
 ======
 
-|PyPI version| |Build Status| |Python 27| |Python 36|
+|PyPI version| |Build Status| |Python 36|
 
 **mtools** is a collection of helper scripts to parse, filter, and visualize
 MongoDB log files (``mongod``, ``mongos``). mtools also includes ``mlaunch``, a
@@ -44,7 +44,7 @@ Requirements and Installation Instructions
 
 The mtools collection is written in Python, and most of the tools only use the
 standard packages shipped with Python. The tools are currently tested with
-Python 2.7 and 3.6.
+Python 3.6.
 
 Some of the tools have additional dependencies, which are listed under the
 specific tool's section. See the `installation instructions
@@ -79,7 +79,5 @@ posted in the `Issues
    :target: https://pypi.python.org/pypi/mtools/
 .. |Build Status| image:: https://img.shields.io/travis/rueckstiess/mtools/master.svg
    :target: https://travis-ci.org/rueckstiess/mtools
-.. |Python 27| image:: https://img.shields.io/badge/Python-2.7-brightgreen.svg?style=flat
-   :target: http://python.org
 .. |Python 36| image:: https://img.shields.io/badge/Python-3.6-brightgreen.svg?style=flat
    :target: http://python.org

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ specific tool's section. See the `installation instructions
 <http://rueckstiess.github.io/mtools/install.html>`__ for more information.
 
 The mtools suite is only tested with actively supported (non End-of-Life)
-versions of the MongoDB server. As of April 2018, that includes MongoDB 3.2
+versions of the MongoDB server. As of June 2019, that includes MongoDB 3.4
 or newer.
 
 Recent Changes

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,7 +2,7 @@
 mtools
 ======
 
-|PyPI version| |Build Status| |Python 27| |Python 36|
+|PyPI version| |Build Status| |Python 36|
 
 **mtools** is a collection of helper scripts to parse, filter, and visualize
 MongoDB log files (``mongod``, ``mongos``). mtools also includes ``mlaunch``, a
@@ -64,7 +64,5 @@ posted in the `Issues
    :target: https://pypi.python.org/pypi/mtools/
 .. |Build Status| image:: https://img.shields.io/travis/rueckstiess/mtools/master.svg
    :target: https://travis-ci.org/rueckstiess/mtools
-.. |Python 27| image:: https://img.shields.io/badge/Python-2.7-brightgreen.svg?style=flat
-   :target: http://python.org
 .. |Python 36| image:: https://img.shields.io/badge/Python-3.6-brightgreen.svg?style=flat
    :target: http://python.org

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -4,20 +4,20 @@ Installation
 
 The mtools collection is written in Python, and most of the tools only use the
 standard packages shipped with Python. The tools are currently tested with
-Python 2.7 and 3.6.
+Python 3.6.
 
 Some of the tools have additional dependencies, which are listed under the
 specific tool's section.
 
-The mtools utilities are only tested with currently supported (non End-of-Life)
-versions of the MongoDB server. As of April 2018, that includes MongoDB 3.2
+The mtools suite is only tested with actively supported (non End-of-Life)
+versions of the MongoDB server. As of June 2019, that includes MongoDB 3.4
 or newer.
 
 Prerequisites
 ~~~~~~~~~~~~~
 
 Python
-   You need to have Python 2.7.x or 3.6.x installed in order to use mtools.
+   You need to have Python 3.6.x installed in order to use mtools.
    Other versions of Python are not currently supported.
 
    To check your Python version, run ``python --version`` on the command line.

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -29,7 +29,7 @@ Releasing a new version
    version to be released.
 #. Increase the version in ``./mtools/version.py`` from ``x.y.z-dev`` to
    ``x.y.z``.
-#. Make sure tests are passing in Python 2.7 and 3.6 via ``tox -e py27,py36``.
+#. Make sure tests are passing in Python 3.6 via ``tox -e py36``.
 #. Update README.rst and CHANGES.rst accordingly.
 #. Any other cleanup tasks.
 #. (optional) leave the release branch for a few days to give others a chance

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -68,7 +68,7 @@ certain tests.
 
    [tox]
    minversion = 2.3
-   envlist = py27
+   envlist = py36
    skipsdist = True
 
    [testenv]
@@ -76,7 +76,7 @@ certain tests.
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
    whitelist_externals = make
-   commands = nosetests -d --with-coverage --cover-package=mtools
+   commands = nosetests --detailed-errors --verbose --with-coverage --cover-package=mtools
 
    [testenv:doc]
    deps =
@@ -120,9 +120,12 @@ certain tests.
    # E123, E125 skipped as they are invalid PEP-8.
    # N802 skipped (function name should be lowercase)
    # N806 skipped (variable in function should be lowercase)
-   ignore = E123,E125,N802,N806
+   # F401 skipped (imported but unused) after verifying current usage is valid
+   # W503 skipped line break before binary operator
+   # C901 skipped: 'MLaunchTool.init' is too complex
+   ignore = E123,E125,N802,N806,F401,W503,C901
    builtins = _
-   exclude=.venv,.git,.tox,dist,*lib/python*,*egg,*figures/*,__init__.py
+   exclude=.venv,.git,.tox,dist,*lib/python*,*egg,*figures/*,__init__.py,build/*,setup.py,mtools/util/*,mtools/test/test_*
    count = true
    statistics = true
    max-complexity = 49

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Database',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
     keywords='MongoDB logs testing',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.3
+minversion = 3.6
 envlist = py36
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.3
-envlist = py27, py36
+envlist = py36
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This PR removes the badges & testing for Python 2.7 (aka "no longer supported"), but doesn't attempt to remove any technical debt for Python 2-3 compatibility.