### PR TITLE
Fix #682: Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: required
+dist: xenial
 python:
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
 install: pip install tox
 script:
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 mtools
 ======
 
-|PyPI version| |Build Status| |Python 36|
+|PyPI version| |Build Status| |Python 36| |Python 37|
 
 **mtools** is a collection of helper scripts to parse, filter, and visualize
 MongoDB log files (``mongod``, ``mongos``). mtools also includes ``mlaunch``, a
@@ -44,7 +44,7 @@ Requirements and Installation Instructions
 
 The mtools collection is written in Python, and most of the tools only use the
 standard packages shipped with Python. The tools are currently tested with
-Python 3.6.
+Python 3.6 and 3.7.
 
 Some of the tools have additional dependencies, which are listed under the
 specific tool's section. See the `installation instructions
@@ -80,4 +80,6 @@ posted in the `Issues
 .. |Build Status| image:: https://img.shields.io/travis/rueckstiess/mtools/master.svg
    :target: https://travis-ci.org/rueckstiess/mtools
 .. |Python 36| image:: https://img.shields.io/badge/Python-3.6-brightgreen.svg?style=flat
+   :target: http://python.org
+.. |Python 37| image:: https://img.shields.io/badge/Python-3.7-brightgreen.svg?style=flat
    :target: http://python.org

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -4,7 +4,7 @@ Installation
 
 The mtools collection is written in Python, and most of the tools only use the
 standard packages shipped with Python. The tools are currently tested with
-Python 3.6.
+Python 3.6 and Python 3.7.
 
 Some of the tools have additional dependencies, which are listed under the
 specific tool's section.
@@ -17,7 +17,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 Python
-   You need to have Python 3.6.x installed in order to use mtools.
+   You need to have Python 3.6.x or 3.7.x installed in order to use mtools.
    Other versions of Python are not currently supported.
 
    To check your Python version, run ``python --version`` on the command line.
@@ -31,6 +31,13 @@ The easiest way to install mtools is via ``pip``. From the command line, run:
 
    pip install mtools
 
+Some mtools scripts have additional :ref:`dependencies`. To install all optional
+dependencies use:
+
+.. code-block:: bash
+
+   pip install mtools[all]
+
 You need to have ``pip`` installed for this to work. If you don't have ``pip``
 installed yet, try ``sudo easy_install pip`` from the command line first, or
 follow the instructions provided on the `pip installation page
@@ -42,8 +49,6 @@ permissions to install into the system directory.
 In that case, you either need to add ``sudo`` in front of the ``pip`` command
 to install into a system directory, or append ``--user`` to install into your
 home directory.
-
-Some mtools scripts have additional :ref:`dependencies`.
 
 Installation from source
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mtools/mlogfilter/mlogfilter.py
+++ b/mtools/mlogfilter/mlogfilter.py
@@ -225,7 +225,11 @@ class MLogFilterTool(LogFileTool):
         if len(self.args['logfile']) > 1:
             # merge log files by time
             for logevent in self._merge_logfiles():
-                yield logevent
+                try:
+                    yield logevent
+                except StopIteration:
+                    return
+
         else:
             # only one file
             for logevent in self.args['logfile'][0]:
@@ -233,7 +237,10 @@ class MLogFilterTool(LogFileTool):
                     logevent._datetime = (logevent.datetime +
                                           timedelta(hours=self
                                                     .args['timezone'][0]))
-                yield logevent
+                try:
+                    yield logevent
+                except StopIteration:
+                    return
 
     def run(self, arguments=None):
         """

--- a/mtools/mplotqueries/plottypes/base_type.py
+++ b/mtools/mplotqueries/plottypes/base_type.py
@@ -61,7 +61,10 @@ class BasePlotType(object):
         """Iterator yielding all logevents from groups dictionary."""
         for key in self.groups:
             for logevent in self.groups[key]:
-                yield logevent
+                try:
+                    yield logevent
+                except StopIteration:
+                    return
 
     @classmethod
     def color_map(cls, group):

--- a/mtools/util/grouping.py
+++ b/mtools/util/grouping.py
@@ -57,7 +57,10 @@ class Grouping(object):
     def __iter__(self):
         """Iterate items in group."""
         for key in self.groups:
-            yield key
+            try:
+                yield key
+            except StopIteration:
+                return
 
     def __len__(self):
         """Return length of group."""

--- a/mtools/util/logfile.py
+++ b/mtools/util/logfile.py
@@ -256,14 +256,18 @@ class LogFile(InputSource):
                 if not self.from_stdin:
                     self.filehandle.seek(0)
 
-                # now raise StopIteration exception
-                raise e
+                # return (instead of raising StopIteration exception) per PEP 479
+                return
 
             # get start date for stdin input
             if not self.start and self.from_stdin:
                 if le and le.datetime:
                     self._start = le.datetime
-            yield le
+
+            try:
+                yield le
+            except StopIteration:
+                return
 
     states = (['PRIMARY', 'SECONDARY', 'DOWN', 'STARTUP', 'STARTUP2',
                'RECOVERING', 'ROLLBACK', 'ARBITER', 'UNKNOWN'])

--- a/mtools/util/logfile.py
+++ b/mtools/util/logfile.py
@@ -212,7 +212,10 @@ class LogFile(InputSource):
         # use readline here because next() iterator uses internal readahead
         # buffer so seek position is wrong
         line = self.filehandle.readline()
-        line = line.decode('utf-8', 'replace')
+
+        if isinstance(line, bytes):
+            line = line.decode('utf-8', 'replace')
+
         if line == '':
             raise StopIteration
         line = line.rstrip('\n')
@@ -284,7 +287,9 @@ class LogFile(InputSource):
 
         ln = 0
         for ln, line in enumerate(self.filehandle):
-            line = line.decode("utf-8", "replace")
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", "replace")
+
             if (self._has_level is None and
                     line[28:31].strip() in LogEvent.log_levels and
                     line[31:39].strip() in LogEvent.log_components):
@@ -495,7 +500,10 @@ class LogFile(InputSource):
                              % self.filehandle.name)
         else:
             self.prev_pos = curr_pos
-        buff = buff.decode("utf-8", "replace")
+
+        if isinstance(buff, bytes):
+            buff = buff.decode("utf-8", "replace")
+
         newline_pos = buff.rfind('\n')
         if prev:
             newline_pos = buff[:newline_pos].rfind('\n')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ordereddict==1.1
 python-dateutil==2.7
-matplotlib==1.4.3
-numpy==1.14.5
-pymongo==3.6.1
-psutil==5.4.2
+matplotlib==3.1.1
+numpy==1.16.4
+pymongo==3.8.0
+psutil==5.6.3

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ try:
     # simplify the default install experience, particularly where a build
     # toolchain is required.
     extras_requires = {
-        "all": ['matplotlib==1.4.3', 'numpy==1.14.5', 'pymongo==3.6.1', 'psutil==5.4.2'],
-        "mlaunch": ['pymongo==3.6.1', 'psutil==5.4.2'],
+        "all": ['matplotlib==3.1.1', 'numpy==1.16.4', 'pymongo==3.8.0', 'psutil==5.6.3'],
+        "mlaunch": ['pymongo==3.8.0', 'psutil==5.6.3'],
         "mlogfilter": [],
-        "mloginfo": ['numpy==1.14.5'],
+        "mloginfo": ['numpy==1.16.4'],
         "mlogvis": [],
-        "mplotqueries": ['matplotlib==1.4.3', 'numpy==1.14.5'],
+        "mplotqueries": ['matplotlib==3.1.1', 'numpy==1.16.4'],
     }
 
     try:
@@ -103,6 +103,7 @@ setup(
         'Topic :: Database',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='MongoDB logs testing',
     extras_require=extras_requires,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.6
-envlist = py36
+envlist = py36, py37
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
- [x] Add `py37` env to tox
- [x] Update to support Python 3.7 and PEP 479
- [x] Update requirements to modern package versions
- [x] Ensure all tests are passing on 3.6 (tested with 3.6.9) and 3.7 (tested with 3.7.4)
- [x] Add to Travis
- [x] Update supported versions in README
