### PR TITLE
Add correct type to `--line-max` argument

### DIFF
--- a/mtools/mlogvis/mlogvis.py
+++ b/mtools/mlogvis/mlogvis.py
@@ -28,7 +28,7 @@ class MLogVisTool(LogFileTool):
                                     help=('filename to output. Default is '
                                           '<original logfile>.html'))
         self.argparser.add_argument('--line-max', action='store',
-                                    default=10000,
+                                    type=int, default=10000,
                                     help=('max count of datapoints at which '
                                           'actual log line strings are not '
                                           'printed any more.'))


### PR DESCRIPTION
Fix this problem:

```
$ mlogvis --line-max 1000000 mongod.log
Traceback (most recent call last):
  File "/home/user/.local/bin/mlogvis", line 10, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.6/site-packages/mtools/mlogvis/mlogvis.py", line 114, in main
    tool.run()
  File "/home/user/.local/lib/python3.6/site-packages/mtools/mlogvis/mlogvis.py", line 87, in run
    json_docs = self._export(True)
  File "/home/user/.local/lib/python3.6/site-packages/mtools/mlogvis/mlogvis.py", line 50, in _export
    if with_line_str and out_count > self.args['line_max']:
TypeError: '>' not supported between instances of 'int' and 'str'
```