### PR TITLE
Fix/bugre #764 json serialize crash w bytes instead of str in pattern.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pip-log.txt
 
 # Doc build files
 _build
+
+# Visual Studio Code (vscode) config
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,5 @@ pip-log.txt
 # Doc build files
 _build
 
-<<<<<<< HEAD
 # Visual Studio Code (vscode) config
-=======
-# VSCode config
->>>>>>> 333c0194e98e70e4f6a008f851f40f85089aed18
 .vscode

--- a/mtools/util/logevent.py
+++ b/mtools/util/logevent.py
@@ -112,8 +112,6 @@ class LogEvent(object):
         self._readTimestamp = None
         self._terminationCause = None
         self._locks = None
-        self._commitedCount = 0
-        self._abortedCount = 0
 
         self._command_calculated = False
         self._command = None
@@ -218,8 +216,9 @@ class LogEvent(object):
                     self._duration = int(matchobj.group(1))
             # SERVER-16176 - Logging of slow checkpoints
             elif "Checkpoint" in self.line_str:
-                groups = re.search("Checkpoint took ([\d]+) seconds to complete", self.line_str)
-                self._duration = int(groups.group(1)) * 1000
+                matchobj = re.search("Checkpoint took ([\d]+) seconds to complete", self.line_str)
+                if matchobj:
+                    self._duration = int(matchobj.group(1)) * 1000
 
         return self._duration
 

--- a/mtools/util/pattern.py
+++ b/mtools/util/pattern.py
@@ -144,7 +144,11 @@ if __name__ == '__main__':
 
         # 20191231 - bugre - issue#764 - adding some more test cases.. based on our mongodb logs (mongod 4.0.3)
         r'{_id: ObjectId(\'528556616dde23324f233168\'), curList: [ "€", "XYZ", "Krown"], allowedSnacks: 1000 }': '{"_id": 1, "allowedSnacks": 1, "curList": [1]}', 
-        r'{_id: "test", curList: [ "1", "abc"] }': '{"_id": 1, "curList": [1]}'
+        r'{_id: "test", curList: [ "1", "abc"] }': '{"_id": 1, "curList": [1]}',
+        
+        # @niccottrell user case and 2nd one extrapolating the 1st one. I think both need changes in simplification process
+        r'{ urls: { $all: [ "https://surtronic.info/" ] } }': '{"urls": {"$all": ["https:1"]}}',
+        r'{ urls: { $all: [ "https://surtronic.info/", "http://url2.com" ] } }': '{"urls": {"$all": ["http://url2.com", "https:1"]}}'
     }
 
     for k,v in tests.items():

--- a/mtools/util/pattern.py
+++ b/mtools/util/pattern.py
@@ -3,7 +3,6 @@
 import json
 import re
 
-import six
 import sys
 
 
@@ -27,10 +26,10 @@ def _decode_pattern_list(data):
 
 def _decode_pattern_dict(data):
     rv = {}
-    for key, value in six.iteritems(data):
+    for key, value in data.items():
         if isinstance(key, bytes):
             key = key.encode('utf-8')
-        if isinstance(key, six.text_type):
+        if isinstance(key, str):
             if key in ['$in', '$gt', '$gte', '$lt', '$lte', '$exists']:
                 return 1
             if key == '$nin':


### PR DESCRIPTION
## Description of changes
in `mtools/utils/pattern.py` a behavior change from py2 to py3 (string.encode('utf-u')) generates a byte string output and not a standart unicode string. And thus, JSON can't serialize this output later.

As mtools 1.6.0 no longer is Python 2.7 compatible, and in Python3 all strings are unicode the part that generates the problem isn't needed anymore. Also used the opportunity to remove 'six' package (introduced on Python 2 to Python3 transition).

Also added `ensure_ascii=False` to json.dumps call so that unicode chars are printed as 'chars' and not as octa or hex char codes.

```       
 return json.dumps(doc, sort_keys=True, separators=(', ', ': '), ensure_ascii=False)
```

## Testing
i've added an additional test case in `mtools/utils/pattern.py`  for this situation

```

    ##
    ## 20191231 - bugre - issue#764 - adding some more test cases.. based on our mongodb logs (mongod 4.0.3)
    ##
    s = (r'{_id: ObjectId(\'528556616dde23324f233168\'), curList: [ "€", "XYZ", "Krown"], allowedSnacks: 1000 }')
    print(json2pattern(s))

```

Fixes #764 