### PR TITLE
Fix #769 mloginfo TypeError logTuple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pip-log.txt
 
 # Doc build files
 _build
+
+# VSCode config
+.vscode

--- a/mtools/mloginfo/sections/query_section.py
+++ b/mtools/mloginfo/sections/query_section.py
@@ -129,12 +129,23 @@ class QuerySection(BaseSection):
             stats['sum'] = sum(group_events) if group_events else 0
             stats['mean'] = (round(stats['sum'] / stats['count'], rounding)
                              if group_events else 0)
-
+            stats['allowDiskUse'] = allowDiskUse
+            
+            ## Fix #769
+            ## IMPORTANT: 'example' must be the last element added to 'stats' and 'tittles'
+            ## or the print_table() -- if overwriting with titles, will crash because in 
+            ## utils/print_table.py " this code: 
+            ###       keys = list(rows[0].keys())
+            ###       headers = override_headers or keys
+            ## will mix assign the 'example' key with another one, because in 'titles', 
+            ## 'example' is the last item of the list, on the 'zip' that follows the above mentioned code
+            ## 
             if self.mloginfo.args['verbose']:
+                # stats['example'] = (grouping[g][0]).pattern
                 stats['example'] = grouping[g][0]
                 titles.append('example')
 
-            stats['allowDiskUse'] = allowDiskUse
+
             table_rows.append(stats)
 
         # sort order depending on field names


### PR DESCRIPTION
<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->
I was wrong on my first assumption, the typeError on printing LogTuple (#769), was being generated, not by adding the LogTuple to the printing sequence, but because it was added at a position that in the print template it was expected to be printed as a string with size restriction, and not as the last position that was 'autoformat'.

This issue was "created" after #708, that did add 'allowDiskUse' stats key after 'example' key in case of '--verbose'

The fix, does move the code block of adding 'example' entry to stats and title so that they are the last entry, also adding a note about it.

Fix #769


## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->

Testing of fix done with logfile line as:
```
2020-01-06T02:35:39.868+0000 I COMMAND [conn137572] command tinkles.tinkles_cyco.web_resource_state command: find { find: "tinkles_cyco.web_resource_state", filter: { urls: { $all: "test" } }, projection: { web_resource_id: 1 }, lsid: { id: UUID("c34f0c66-8423-4a3a-beeb-0d2ede0415e3") }, $clusterTime: { clusterTime: Timestamp(1578278139, 718), signature: { hash: BinData(0, 67BB9AC67D809AD263875805B445C4BCE059D064), keyId: 6736797216142262274 } }, $db: "tinkles", $readPreference: { mode: "primary" } } planSummary: IXSCAN { urls: 1 } keysExamined:1 docsExamined:1 cursorExhausted:1 numYields:1 nreturned:1 reslen:396 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 2 } }, Collection: { acquireCount: { r: 2 } } } storage:{ data: { bytesRead: 32523, timeReadingMicros: 16629 } } protocol:op_msg 103ms
```

To test it, the error/crash is generated, moving this [line](https://github.com/bugre/mtools/blob/a3c1353b238efb78a59fc9db273b1d6be1a6db21/mtools/mloginfo/sections/query_section.py#L132) of code

```python
            stats['allowDiskUse'] = allowDiskUse
```

to just above this [line](https://github.com/bugre/mtools/blob/a3c1353b238efb78a59fc9db273b1d6be1a6db21/mtools/mloginfo/sections/query_section.py#L149) 
```python
            table_rows.append(stats)
```



O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            | 10.14.6
| Windows          |
