### PR TITLE
Fix #666: SSL parameters to mlaunch are not documented on website

### DIFF
--- a/doc/mlaunch.rst
+++ b/doc/mlaunch.rst
@@ -99,7 +99,7 @@ Usage
                 [--hostname HOSTNAME] [--auth] [--username USERNAME]
                 [--password PASSWORD] [--auth-db DB]
                 [--auth-roles [ROLE [ROLE ...]]] [--auth-role-docs]
-                [--initial-user] [--sslCAFile SSLCAFILE]
+                [--no-initial-user] [--sslCAFile SSLCAFILE]
                 [--sslCRLFile SSLCRLFILE] [--sslAllowInvalidHostnames]
                 [--sslAllowInvalidCertificates]
                 [--sslMode {disabled,allowSSL,preferSSL,requireSSL}]
@@ -328,8 +328,8 @@ Authentication Parameters
 ``--auth-role-docs``
    Use with ``--auth-roles`` to interpret roles specified as JSON documents.
 
-``--initial-user``
-   Create an initial user if auth is enabled (default=true).
+``--no-initial-user``
+   Do not create an initial user if auth is enabled.
 
 Optional Parameters
 ^^^^^^^^^^^^^^^^^^^

--- a/doc/mlaunch.rst
+++ b/doc/mlaunch.rst
@@ -99,6 +99,20 @@ Usage
                 [--hostname HOSTNAME] [--auth] [--username USERNAME]
                 [--password PASSWORD] [--auth-db DB]
                 [--auth-roles [ROLE [ROLE ...]]]
+                [--initial-user] [--sslCAFile SSLCAFILE]
+                [--sslCRLFile SSLCRLFILE] [--sslAllowInvalidHostnames]
+                [--sslAllowInvalidCertificates] [--sslOnNormalPorts]
+                [--sslMode {disabled,allowSSL,preferSSL,requireSSL}]
+                [--sslPEMKeyFile SSLPEMKEYFILE]
+                [--sslPEMKeyPassword SSLPEMKEYPASSWORD]
+                [--sslClusterFile SSLCLUSTERFILE]
+                [--sslClusterPassword SSLCLUSTERPASSWORD]
+                [--sslDisabledProtocols SSLDISABLEDPROTOCOLS]
+                [--sslWeakCertificateValidation]
+                [--sslAllowConnectionsWithoutCertificates] [--sslFIPSMode]
+                [--sslClientCertificate SSLCLIENTCERTIFICATE]
+                [--sslClientPEMKeyFile SSLCLIENTPEMKEYFILE]
+                [--sslClientPEMKeyPassword SSLCLIENTPEMKEYPASSWORD]
 
 For convenience and backwards compatibility, the ``init`` command is the
 default command and can be omitted.
@@ -312,6 +326,8 @@ Authentication Parameters
    ``my_s3cr3t_p4ssw0rd``. It will use the default roles and place the user in
    the ``admin`` database. ``mlaunch`` will
 
+``--initial-user``
+   Create an initial user if auth is enabled (default=true).
 
 Optional Parameters
 ^^^^^^^^^^^^^^^^^^^
@@ -346,6 +362,66 @@ Optional Parameters
 
    This command will look for the ``mongod`` binary in ``./build/bin/mongod``
    instead of the default location.
+
+TLS/SSL options
+^^^^^^^^^^^^^^^
+``--sslCAFile SSLCAFILE``
+   Certificate Authority file for TLS/SSL.
+
+``--sslCRLFile SSLCRLFILE``
+   Certificate Revocation List file for TLS/SSL.
+
+``--sslAllowInvalidHostnames``
+   Allow client and server certificates to provide non-matching hostnames.
+
+``--sslAllowInvalidCertificates``
+   Allow client or server connections with invalid
+   certificates.
+
+Server TLS/SSL options
+^^^^^^^^^^^^^^^^^^^^^^
+
+``--sslOnNormalPorts``
+   Use TLS/SSL on configured ports.
+
+``--sslMode {disabled,allowSSL,preferSSL,requireSSL}``
+   Set the TLS/SSL operation mode.
+
+``--sslPEMKeyFile SSLPEMKEYFILE``
+   PEM file for TLS/SSL.
+
+``--sslPEMKeyPassword SSLPEMKEYPASSWORD``
+   PEM file password.
+
+``--sslClusterFile SSLCLUSTERFILE``
+   Key file for internal TLS/SSL authentication.
+
+``--sslClusterPassword SSLCLUSTERPASSWORD``
+   Internal authentication key file password.
+
+``--sslDisabledProtocols SSLDISABLEDPROTOCOLS``
+   Comma separated list of TLS protocols to disable [TLS1_0,TLS1_1,TLS1_2].
+
+``--sslWeakCertificateValidation``
+   Allow client to connect without presenting a certificate.
+
+``--sslAllowConnectionsWithoutCertificates``
+   Allow client to connect without presenting a certificate.
+
+``--sslFIPSMode``
+   Activate FIPS 140-2 mode.
+
+Client TLS/SSL options
+^^^^^^^^^^^^^^^^^^^^^^
+
+``--sslClientCertificate SSLCLIENTCERTIFICATE``
+   Client certificate file for TLS/SSL.
+
+``--sslClientPEMKeyFile SSLCLIENTPEMKEYFILE``
+   Client PEM file for TLS/SSL.
+
+``--sslClientPEMKeyPassword SSLCLIENTPEMKEYPASSWORD``
+   Client PEM file password.
 
 -----
 

--- a/doc/mlaunch.rst
+++ b/doc/mlaunch.rst
@@ -98,7 +98,7 @@ Usage
                 [--port PORT] [--binarypath PATH] [--dir DIR]
                 [--hostname HOSTNAME] [--auth] [--username USERNAME]
                 [--password PASSWORD] [--auth-db DB]
-                [--auth-roles [ROLE [ROLE ...]]]
+                [--auth-roles [ROLE [ROLE ...]]] [--auth-role-docs]
                 [--initial-user] [--sslCAFile SSLCAFILE]
                 [--sslCRLFile SSLCRLFILE] [--sslAllowInvalidHostnames]
                 [--sslAllowInvalidCertificates]
@@ -324,6 +324,9 @@ Authentication Parameters
    server, 1 mongos, and create the user ``thomas`` with password
    ``my_s3cr3t_p4ssw0rd``. It will use the default roles and place the user in
    the ``admin`` database. ``mlaunch`` will
+
+``--auth-role-docs``
+   Use with ``--auth-roles`` to interpret roles specified as JSON documents.
 
 ``--initial-user``
    Create an initial user if auth is enabled (default=true).

--- a/doc/mlaunch.rst
+++ b/doc/mlaunch.rst
@@ -101,7 +101,7 @@ Usage
                 [--auth-roles [ROLE [ROLE ...]]]
                 [--initial-user] [--sslCAFile SSLCAFILE]
                 [--sslCRLFile SSLCRLFILE] [--sslAllowInvalidHostnames]
-                [--sslAllowInvalidCertificates] [--sslOnNormalPorts]
+                [--sslAllowInvalidCertificates]
                 [--sslMode {disabled,allowSSL,preferSSL,requireSSL}]
                 [--sslPEMKeyFile SSLPEMKEYFILE]
                 [--sslPEMKeyPassword SSLPEMKEYPASSWORD]
@@ -380,9 +380,6 @@ TLS/SSL options
 
 Server TLS/SSL options
 ^^^^^^^^^^^^^^^^^^^^^^
-
-``--sslOnNormalPorts``
-   Use TLS/SSL on configured ports.
 
 ``--sslMode {disabled,allowSSL,preferSSL,requireSSL}``
    Set the TLS/SSL operation mode.

--- a/doc/mlaunch.rst
+++ b/doc/mlaunch.rst
@@ -108,7 +108,6 @@ Usage
                 [--sslClusterFile SSLCLUSTERFILE]
                 [--sslClusterPassword SSLCLUSTERPASSWORD]
                 [--sslDisabledProtocols SSLDISABLEDPROTOCOLS]
-                [--sslWeakCertificateValidation]
                 [--sslAllowConnectionsWithoutCertificates] [--sslFIPSMode]
                 [--sslClientCertificate SSLCLIENTCERTIFICATE]
                 [--sslClientPEMKeyFile SSLCLIENTPEMKEYFILE]
@@ -398,9 +397,6 @@ Server TLS/SSL options
 
 ``--sslDisabledProtocols SSLDISABLEDPROTOCOLS``
    Comma separated list of TLS protocols to disable [TLS1_0,TLS1_1,TLS1_2].
-
-``--sslWeakCertificateValidation``
-   Allow client to connect without presenting a certificate.
 
 ``--sslAllowConnectionsWithoutCertificates``
    Allow client to connect without presenting a certificate.

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -356,8 +356,6 @@ class MLaunchTool(BaseCmdLineTool):
                                     'invalid certificates'))
 
         ssl_server_args = init_parser.add_argument_group('Server TLS/SSL options')
-        ssl_server_args.add_argument('--sslOnNormalPorts', action='store_true',
-                                     help='use TLS/SSL on configured ports')
         ssl_server_args.add_argument('--sslMode',
                                      help='set the TLS/SSL operation mode',
                                      choices=('disabled allowSSL preferSSL '

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -374,10 +374,6 @@ class MLaunchTool(BaseCmdLineTool):
                                      help=('comma separated list of TLS '
                                            'protocols to disable '
                                            '[TLS1_0,TLS1_1,TLS1_2]'))
-        ssl_server_args.add_argument('--sslWeakCertificateValidation',
-                                     action='store_true',
-                                     help=('allow client to connect without '
-                                           'presenting a certificate'))
         ssl_server_args.add_argument(('--sslAllowConnectionsWithout'
                                       'Certificates'), action='store_true',
                                      help=('allow client to connect without '

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -328,7 +328,7 @@ class MLaunchTool(BaseCmdLineTool):
                                        'required to run the stop command '
                                        '(requires --auth, default="%s")'
                                        % ' '.join(self._default_auth_roles)))
-        init_parser.add_argument('--no-initial-user', action='store_false',
+        init_parser.add_argument('--initial-user', action='store_false',
                                  default=True, dest='initial-user',
                                  help=('create an initial user if auth is '
                                        'enabled (default=true)'))

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -341,10 +341,10 @@ class MLaunchTool(BaseCmdLineTool):
 
         ssl_args = init_parser.add_argument_group('TLS/SSL options')
         ssl_args.add_argument('--sslCAFile',
-                              help='Certificate Authority file for SSL',
+                              help='Certificate Authority file for TLS/SSL',
                               type=is_file)
         ssl_args.add_argument('--sslCRLFile',
-                              help='Certificate Revocation List file for SSL',
+                              help='Certificate Revocation List file for TLS/SSL',
                               type=is_file)
         ssl_args.add_argument('--sslAllowInvalidHostnames',
                               action='store_true',
@@ -357,17 +357,17 @@ class MLaunchTool(BaseCmdLineTool):
 
         ssl_server_args = init_parser.add_argument_group('Server TLS/SSL options')
         ssl_server_args.add_argument('--sslOnNormalPorts', action='store_true',
-                                     help='use ssl on configured ports')
+                                     help='use TLS/SSL on configured ports')
         ssl_server_args.add_argument('--sslMode',
-                                     help='set the SSL operation mode',
+                                     help='set the TLS/SSL operation mode',
                                      choices=('disabled allowSSL preferSSL '
                                               'requireSSL'.split()))
         ssl_server_args.add_argument('--sslPEMKeyFile',
-                                     help='PEM file for ssl', type=is_file)
+                                     help='PEM file for TLS/SSL', type=is_file)
         ssl_server_args.add_argument('--sslPEMKeyPassword',
                                      help='PEM file password')
         ssl_server_args.add_argument('--sslClusterFile',
-                                     help=('key file for internal SSL '
+                                     help=('key file for internal TLS/SSL '
                                            'authentication'), type=is_file)
         ssl_server_args.add_argument('--sslClusterPassword',
                                      help=('internal authentication key '
@@ -389,10 +389,10 @@ class MLaunchTool(BaseCmdLineTool):
 
         ssl_client_args = init_parser.add_argument_group('Client TLS/SSL options')
         ssl_client_args.add_argument('--sslClientCertificate',
-                                     help='client certificate file for ssl',
+                                     help='client certificate file for TLS/SSL',
                                      type=is_file)
         ssl_client_args.add_argument('--sslClientPEMKeyFile',
-                                     help='client PEM file for ssl',
+                                     help='client PEM file for TLS/SSL',
                                      type=is_file)
         ssl_client_args.add_argument('--sslClientPEMKeyPassword',
                                      help='client PEM file password')

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -331,10 +331,10 @@ class MLaunchTool(BaseCmdLineTool):
         init_parser.add_argument('--auth-role-docs', action='store_true',
                                  default=False,
                                  help='auth-roles are JSON documents')
-        init_parser.add_argument('--initial-user', action='store_false',
+        init_parser.add_argument('--no-initial-user', action='store_false',
                                  default=True, dest='initial-user',
-                                 help=('create an initial user if auth is '
-                                       'enabled (default=true)'))
+                                 help=('Do not create an initial user if auth '
+                                       'is enabled'))
 
         # ssl
         def is_file(arg):

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -328,9 +328,6 @@ class MLaunchTool(BaseCmdLineTool):
                                        'required to run the stop command '
                                        '(requires --auth, default="%s")'
                                        % ' '.join(self._default_auth_roles)))
-        init_parser.add_argument('--auth-role-docs', action='store_true',
-                                 default=False,
-                                 help='auth-roles are json documents')
         init_parser.add_argument('--no-initial-user', action='store_false',
                                  default=True, dest='initial-user',
                                  help=('create an initial user if auth is '

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -328,6 +328,9 @@ class MLaunchTool(BaseCmdLineTool):
                                        'required to run the stop command '
                                        '(requires --auth, default="%s")'
                                        % ' '.join(self._default_auth_roles)))
+        init_parser.add_argument('--auth-role-docs', action='store_true',
+                                 default=False,
+                                 help='auth-roles are JSON documents')
         init_parser.add_argument('--initial-user', action='store_false',
                                  default=True, dest='initial-user',
                                  help=('create an initial user if auth is '

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -339,7 +339,7 @@ class MLaunchTool(BaseCmdLineTool):
                 init_parser.error("The file [%s] does not exist" % arg)
             return arg
 
-        ssl_args = init_parser.add_argument_group('SSL Options')
+        ssl_args = init_parser.add_argument_group('TLS/SSL options')
         ssl_args.add_argument('--sslCAFile',
                               help='Certificate Authority file for SSL',
                               type=is_file)
@@ -355,7 +355,7 @@ class MLaunchTool(BaseCmdLineTool):
                               help=('allow client or server connections with '
                                     'invalid certificates'))
 
-        ssl_server_args = init_parser.add_argument_group('Server SSL Options')
+        ssl_server_args = init_parser.add_argument_group('Server TLS/SSL options')
         ssl_server_args.add_argument('--sslOnNormalPorts', action='store_true',
                                      help='use ssl on configured ports')
         ssl_server_args.add_argument('--sslMode',
@@ -387,7 +387,7 @@ class MLaunchTool(BaseCmdLineTool):
         ssl_server_args.add_argument('--sslFIPSMode', action='store_true',
                                      help='activate FIPS 140-2 mode')
 
-        ssl_client_args = init_parser.add_argument_group('Client SSL Options')
+        ssl_client_args = init_parser.add_argument_group('Client TLS/SSL options')
         ssl_client_args.add_argument('--sslClientCertificate',
                                      help='client certificate file for ssl',
                                      type=is_file)


### PR DESCRIPTION
- Reconciled undocumented parameters in `mlaunch init --help`
- Replaced SSL with TLS/SSL in option help text to match upstream server documentation
- Removed unimplemented `--auth-role-docs` option
- Rename `--no-initial-user` to `--initial-user` to match actual usage