### PR TITLE
Wait for each RS to elect a primary

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1691,6 +1691,10 @@ class MLaunchTool(BaseCmdLineTool):
                       % (name, self.config_docs[name]))
             print("replica set '%s' initialized." % name)
 
+        print("waiting for localhost:%i to elect a primary" % port)
+        con = self.client(['localhost:%i' % port], replicaSet=name, serverSelectionTimeoutMS=30000)
+        con['admin'].command({'ping': 1})
+
     def _add_user(self, port, name, password, database, roles):
         con = self.client('localhost:%i' % port)
         v = con['admin'].command('isMaster').get('maxWireVersion', 0)


### PR DESCRIPTION
In a sharded replica set, wait for each of the shards to elect
a primary before continuing to hopefully fix #691
