### PR TITLE
Update link to d3js

### DIFF
--- a/mtools/data/index.html
+++ b/mtools/data/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title></title>
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+    <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
     <script>
       window.mlogvis = (function () {
 


### PR DESCRIPTION
Update link to d3js to "protocol-less" link, so browser can decide wheather to use http or https.

The problem was, when publishing result on domain with https support.

<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->
Changed link to d3js from http://d3js... to //d3js...

## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->


O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            | 
| Windows          |
