### PR TITLE
Fix #818: mplotqueries --overlay example not working

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 import functools
 import json

--- a/mtools/mplotqueries/mplotqueries.py
+++ b/mtools/mplotqueries/mplotqueries.py
@@ -317,7 +317,10 @@ class MPlotQueriesTool(LogFileTool):
 
         # dump plots and handle exceptions
         try:
-            pickle.dump(self.plot_instances, open(target_file, 'wb'), -1)
+            # Pickle protocol version 4 was added in Python 3.4. It adds
+            # support for very large objects, pickling more kinds of objects,
+            # and some data format optimizations.
+            pickle.dump(self.plot_instances, open(target_file, 'wb'), protocol=4)
             print("Created overlay: %s" % uid)
         except Exception as e:
             print("Error: %s" % e)

--- a/mtools/util/logfile.py
+++ b/mtools/util/logfile.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import os
 import re
 import sys
@@ -58,6 +56,21 @@ class LogFile(InputSource):
         # make sure bounds are calculated before starting to iterate,
         # including potential year rollovers
         self._calculate_bounds()
+
+    def __getstate__(self):
+        """
+        Return state values to be pickled.
+        """
+        if (self.name != '<stdin>'):
+            return (self.name)
+        else:
+            return ()
+
+    def __setstate__(self, state):
+        """
+        Restore state from the unpickled state values.
+        """
+        self.name = state
 
     @property
     def start(self):

--- a/mtools/util/presplit.py
+++ b/mtools/util/presplit.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 
 from bson.min_key import MinKey


### PR DESCRIPTION
 - add __getstate__ to avoid serialising LogFile TextIOWrapper object
 - set pickle protocol version to 4 for compatibility (instead of -1/highest)
 - remove unnecessary __future__ imports
