### PR TITLE
Connect to the entire replicaset to wait for primary

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1915,7 +1915,7 @@ class MLaunchTool(BaseCmdLineTool):
                   for x in self.config_docs[self.args['name']]['members']])
         rs_name = self.config_docs[self.args['name']]['_id']
         mrsc = self.client(hosts, replicaSet=rs_name,
-                           serverSelectionTimeoutMS=30000)
+                           serverSelectionTimeoutMS=30000, directConnection=False)
 
         if mrsc.is_primary:
             # update cluster tags now that we have a primary


### PR DESCRIPTION
## Description of changes
Parameter "directConnection=False" added to the host connection parameters.

## Testing
The following command should start a new replicaset and add a user with the default username and password:
mlaunch init --replicaset --name rs0 --port 30000 --dir db --auth

O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            |  Ubuntu 20.04.3 LTS (WSL)
| macOS            | 
| Windows          | 5.10.16.3-microsoft-standard-WSL2
