### PR TITLE
added query pattern extraction on aggregate operation

### DIFF
--- a/mtools/util/logevent.py
+++ b/mtools/util/logevent.py
@@ -474,7 +474,8 @@ class LogEvent(object):
                     self._pattern = self._find_pattern('q: ')
             elif self.command == 'find':
                 self._pattern = self._find_pattern('filter: ')
-
+            elif self.command == 'aggregate':
+                self._pattern = self._find_pattern('pipeline: ')
         return self._pattern
 
     @property
@@ -500,6 +501,8 @@ class LogEvent(object):
             elif self.command == 'find':
                 self._actual_query = self._find_pattern('filter: ',
                                                         actual=True)
+            elif self.command == 'aggregate':
+                self._pattern = self._find_pattern('pipeline: ', actual=True)
 
         return self._actual_query
 
@@ -1006,9 +1009,9 @@ class LogEvent(object):
         brace_counter = 0
         search_str = self.line_str[start_idx + len(trigger):]
 
-        for match in re.finditer(r'{|}', search_str):
+        for match in re.finditer(r'\[|{|}|\]', search_str):
             stop_idx = match.start()
-            if search_str[stop_idx] == '{':
+            if search_str[stop_idx] in ['{', '[']:
                 brace_counter += 1
             else:
                 brace_counter -= 1

--- a/mtools/util/pattern.py
+++ b/mtools/util/pattern.py
@@ -87,22 +87,22 @@ def json2pattern(s, debug = False):
 
     # make valid JSON by wrapping field names in quotes
     s, _ = re.subn(r'([{,])\s*([^,{\s\'"]+)\s*:', ' \\1 "\\2" : ', s)
-    if debug : print (s, file=sys.stderr) 
+    if debug : print (s, file=sys.stderr)
 
     # handle shell values that are not valid JSON
     s = shell2json(s)
     if debug : print (s, file=sys.stderr)
-    
+
     # convert to 1 where possible, to get rid of things like new Date(...)
     s, _ = re.subn(r'([:,\[])\s*([^{}\[\]"]+?)\s*([,}\]])', '\\1 1 \\3', s)
     if debug : print (s, file=sys.stderr)
 
 
     # replace list values by 1. Not the '$in/$nin' lists, but the like of: {..., "attrib" : ["val1", "val2", "3"],...}
-    # updated regex, using positive lookahead and lookbehind to check for a " (quote) 
-    # right after '['  and before ']' to correctly handle cases where a ']' is part of the value and 
+    # updated regex, using positive lookahead and lookbehind to check for a " (quote)
+    # right after '['  and before ']' to correctly handle cases where a ']' is part of the value and
     # also cases where list values are url's "nnn://aaa.bbb"  will correctly be simplified to '1'
-    s, _ = re.subn(r'("\S+"\s*:\s*\[\s*(?=\"))(.+)((?<=\")\s*\]\s*[,}])', '\\1 1 \\3', s)
+    # s, _ = re.subn(r'("\S+"\s*:\s*\[\s*(?=\"))(.+)((?<=\")\s*\]\s*[,}])', '\\1 1 \\3', s)
 
     if debug : print (s, file=sys.stderr)
 
@@ -139,22 +139,22 @@ if __name__ == '__main__':
     # define as True to get debug output of regex processing printed to stderr
     debug = False
 
-    tests = { 
+    tests = {
         '{d: {$gt: 2, $lt: 4}, b: {$gte: 3}, c: {$nin: [1, "foo", "bar"]}, "$or": [{a:"1uno"}, {b:"1uno"}] }'                : '{"$or": [{"a": 1}, {"b": 1}], "b": 1, "c": {"$nin": 1}, "d": 1}',
-        '{a: {$gt: 2, $lt: 4}, "b": {$nin: [1, 2, 3]}, "$or": [{a:1}, {b:1}] }'                                              : '{"$or": [{"a": 1}, {"b": 1}], "a": 1, "b": {"$nin": 1}}', 
-        "{a: {$gt: 2, $lt: 4}, b: {$in: [ ObjectId('1234564863acd10e5cbf5f6e'), ObjectId('1234564863acd10e5cbf5f7e') ] } }"  : '{"a": 1, "b": 1}', 
-        "{ sk: -1182239108, _id: { $in: [ ObjectId('1234564863acd10e5cbf5f6e'), ObjectId('1234564863acd10e5cbf5f7e') ] } }"  : '{"_id": 1, "sk": 1}', 
-        '{ a: 1, b: { c: 2, d: "text" }, e: "more test" }'                                                                   : '{"a": 1, "b": {"c": 1, "d": 1}, "e": 1}', 
+        '{a: {$gt: 2, $lt: 4}, "b": {$nin: [1, 2, 3]}, "$or": [{a:1}, {b:1}] }'                                              : '{"$or": [{"a": 1}, {"b": 1}], "a": 1, "b": {"$nin": 1}}',
+        "{a: {$gt: 2, $lt: 4}, b: {$in: [ ObjectId('1234564863acd10e5cbf5f6e'), ObjectId('1234564863acd10e5cbf5f7e') ] } }"  : '{"a": 1, "b": 1}',
+        "{ sk: -1182239108, _id: { $in: [ ObjectId('1234564863acd10e5cbf5f6e'), ObjectId('1234564863acd10e5cbf5f7e') ] } }"  : '{"_id": 1, "sk": 1}',
+        '{ a: 1, b: { c: 2, d: "text" }, e: "more test" }'                                                                   : '{"a": 1, "b": {"c": 1, "d": 1}, "e": 1}',
         '{ _id: ObjectId(\'528556616dde23324f233168\'), config: { _id: 2, host: "localhost:27017" }, ns: "local.oplog.rs" }' : '{"_id": 1, "config": {"_id": 1, "host": 1}, "ns": 1}',
 
         # 20191231 - bugre - issue#764 - adding some more test cases.. based on our mongodb logs (mongod 4.0.3)
-        r'{_id: ObjectId(\'528556616dde23324f233168\'), curList: [ "€", "XYZ", "Krown"], allowedSnacks: 1000 }'              : '{"_id": 1, "allowedSnacks": 1, "curList": [1]}', 
+        r'{_id: ObjectId(\'528556616dde23324f233168\'), curList: [ "€", "XYZ", "Krown"], allowedSnacks: 1000 }'              : '{"_id": 1, "allowedSnacks": 1, "curList": [1]}',
         r'{_id: "test", curList: [ "1onum]pas", "ab\]c" ] }'                                                                 : '{"_id": 1, "curList": [1]}',
         r'{ $and: [ { mode: ObjectId(\'5aafd085edb85e0dc09dd985\') }, { _id: { $ne: ObjectId(\'5e015519877718752d63dd9c\') } }, ' 
             '{ snack: { $in: [ "BLA", "RUN", "BLE" ] } }, { $or: [ { $and: [ { kind: "Solar" }, { wind: true }, '
-            '{ beginTime: { $gte: new Date(1577134729858) } } ] }, { $and: [ { kind: "event" }, { endTime: { $gte: new Date(1577739529858) } } ] } ] } ] }'  : 
+            '{ beginTime: { $gte: new Date(1577134729858) } } ] }, { $and: [ { kind: "event" }, { endTime: { $gte: new Date(1577739529858) } } ] } ] } ] }'  :
                 '{"$and": [{"mode": 1}, {"_id": {"$ne": 1}}, {"snack": 1}, {"$or": [{"$and": [{"kind": 1}, {"wind": 1}, {"beginTime": 1}]}, {"$and": [{"kind": 1}, {"endTime": 1}]}]}]}',
-        
+
         # @niccottrell use case and 2nd one extrapolating the 1st one. 
         r'{ urls: { $all: [ "https://surtronic.info/" ] } }'                      : '{"urls": {"$all": [1]}}',
         r'{ urls: { $all: [ "https://surtronic.info/", "http://url2.com" ] } }'   : '{"urls": {"$all": [1]}}'


### PR DESCRIPTION
Issue [861](https://github.com/rueckstiess/mtools/issues/861)

## Description of changes
Added query pattern extraction on aggregate operation


## Testing
Run mloginfo mongo.log --queries whioch contains aggregate operations as well
### Result
```
namespace                  operation    pattern         count    min (ms)    max (ms)    95%-ile (ms)    sum (ms)    mean (ms)    allowDiskUse
test_db.test_coll1         find        {"field1": 1, "field2": 1, "field3": 1, "field4": 1, "field5": 1}          1         470         470           470.0         470        470.0    None
test_db.test_coll2         aggregate         [{"$match": {"field1": 1}}, {"$unwind": 1}, {"$match": {"field2": {"$ne": 1}, "field3": 1, "field4": 1}}, {"$group": {"Count": {"$sum": 1}, "_id": 1}}]         1         252         252           252.0         252        252.0    None
```

O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| macOS            | 12.2
