### PR TITLE
Report exception message when binary invocation fails

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1584,9 +1584,9 @@ class MLaunchTool(BaseCmdLineTool):
 
         try:
             out = check_mongo_server_output(binary, '--help')
-        except Exception:
-            raise SystemExit("Fatal error trying get output from `%s`."
-                "Is the binary in your path?" % binary)
+        except Exception as exc:
+            raise SystemExit("Fatal error trying get output from `%s`: %s. "
+                "Is the binary in your path?" % (exc, binary))
 
         accepted_arguments = []
         # extract all arguments starting with a '-'


### PR DESCRIPTION
+ python3 -m mtools.mlaunch.mlaunch --dir /tmpfs/db --binarypath /opt/mongodb/bin --setParameter enableTestCommands=1 --setParameter acceptApiVersion2=1 --setParameter diagnosticDataCollectionEnabled=false --replicaset --name test-rs --nodes 2 --arbiter
Fatal error trying get output from `/opt/mongodb/bin/mongod`.Is the binary in your path?

<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->


## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->


O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            | 
| Windows          |
