### PR TITLE
Fix handling of directConnection default

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -47,7 +47,7 @@ class MongoConnection(Connection):
     MongoConnection class.
 
     Wrapper around Connection (itself conditionally a MongoClient or
-    pymongo.Connection) to specify timeout and directConnection.
+    pymongo.Connection) to specify timeout.
     """
 
     def __init__(self, *args, **kwargs):

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -51,7 +51,8 @@ class MongoConnection(Connection):
     """
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('directConnection', True)
+        if not kwargs.get('replicaSet'):
+            kwargs.setdefault('directConnection', True)
         kwargs.setdefault('serverSelectionTimeoutMS', 1)
 
         # Set client application name for MongoDB 3.4+ servers


### PR DESCRIPTION
<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->
Only add `directConnection=True` when not connecting to a replica set.

## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->

`launch init  --replicaset --name repl0 --nodes 3 --port 27017 --hostname localhost`

O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            |  12.4
| Windows          |
