### PR TITLE
Output the log path when mongod/mongos launch fails

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1762,11 +1762,15 @@ class MLaunchTool(BaseCmdLineTool):
             shard_names = [None]
         return shard_names
 
+    def _get_log_path(self, command_str):
+        match = re.search(r'--logpath ([^\s]+)', command_str)
+        return match.group(1)
+
     def _get_last_error_log(self, command_str):
-        logpath = re.search(r'--logpath ([^\s]+)', command_str)
+        log_path = self._get_log_path(command_str)
         loglines = ''
         try:
-            with open(logpath.group(1), 'rb') as logfile:
+            with open(log_path, 'rb') as logfile:
                 for line in logfile:
                     if not line.startswith('----- BEGIN BACKTRACE -----'):
                         loglines += line
@@ -1811,9 +1815,10 @@ class MLaunchTool(BaseCmdLineTool):
             except subprocess.CalledProcessError as e:
                 print(e.output)
                 print(self._get_last_error_log(command_str), file=sys.stderr)
+                log_path = self._get_log_path(command_str)
                 raise SystemExit("can't start process, return code %i. "
-                                 "tried to launch: %s"
-                                 % (e.returncode, command_str))
+                                 "tried to launch: %s\nlog: %s"
+                                 % (e.returncode, command_str, log_path))
 
         if wait:
             self.wait_for(ports)


### PR DESCRIPTION
When mlaunch fails to spawn mongod or mongos, it tries to output a log excerpt. This exceprt can be useless in some situations, e.g.:

```
launching: config server on port 16046                                                                                 
b'{"t":{"$date":"2022-06-23T00:01:17.482Z"},"s":"I",  "c":"CONTROL",  "id":5760901, "ctx":"-","msg":"Applied --setParam
eter options","attr":{"serverParameters":{"enableTestCommands":{"default":false,"value":true}}}}\nabout to fork child p
rocess, waiting until server is ready for connections.\nforked process: 6585\nERROR: child process failed, exited with 
48\nTo see additional information in this output, start without the "--fork" option.\n'                                
                                                                                                                       
can't start process, return code 48. tried to launch: "/usr/local/m/versions/6.0/mongod" --replSet shard01 --dbpath "/m
nt/zram/mongodb/6.0-scm/shard01/rs1/db" --logpath "/mnt/zram/mongodb/6.0-scm/shard01/rs1/mongod.log" --port 16042 --for
k  --setParameter "enableTestCommands=1" --filePermissions "0666" --shardsvr --wiredTigerCacheSizeGB 1        
```

To assist in troubleshooting, print the path to the logfile also.