### PR TITLE
Update default mongodb version to "0.0.0"

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -910,7 +910,7 @@ class MLaunchTool(BaseCmdLineTool):
         try:
             out = check_mongo_server_output(binary, '--version')
         except Exception:
-            return "0.0"
+            return "0.0.0"
 
         buf = BytesIO(out)
         current_version = buf.readline().strip().decode('utf-8')


### PR DESCRIPTION
## Description of changes
Update default mongodb version to "0.0.0"

## Testing
If getting the mongodb version fails then users can still use the --csrs flag. As it checks against "0.0.0"
https://github.com/rueckstiess/mtools/blob/develop/mtools/mlaunch/mlaunch.py#L659-L666


O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            |  X
| macOS            | 
| Windows          |
