### PR TITLE
mlaunch: Use default SASL/SCRAM mechanisms when creating users.

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1853,19 +1853,12 @@ class MLaunchTool(BaseCmdLineTool):
             con.close()
             con = self.client('localhost:%i' % port, replicaSet=set_name,
                               serverSelectionTimeoutMS=10000)
-        v = ismaster.get('maxWireVersion', 0)
-        if v >= 7:
-            # Until drivers have implemented SCRAM-SHA-256, use old mechanism.
-            opts = {'mechanisms': ['SCRAM-SHA-1']}
-        else:
-            opts = {}
 
         if database == "$external":
             password = None
 
         try:
-            con[database].command("createUser", name, pwd=password, roles=roles,
-                                   **opts)
+            con[database].command("createUser", name, pwd=password, roles=roles)
         except OperationFailure as e:
             raise e
 


### PR DESCRIPTION
## Description of changes
There is currently a [check](https://github.com/rueckstiess/mtools/blob/be1409770e672f3b8cb6f45eaa514e1d76dfa69e/mtools/mlaunch/mlaunch.py#L1702-L1704) that explicitly prevents creating a SCRAM-SHA-256 user credential for newer server versions. Remove that SASL/SCRAM default mechanism override now that all official MongoDB drivers support SASL/SCRAM mechanism SCRAM-SHA-256 (see [DRIVERS-439](https://jira.mongodb.org/browse/DRIVERS-439)).

Fixes https://github.com/rueckstiess/mtools/issues/879

## Testing
1. Create a standalone deployment with auth enabled.
```bash
python3 mtools/mlaunch/mlaunch.py init \
    --dir ~/data/mtools/5.0.0 \
    --single \
    --binarypath $(m bin 5.0.0)  \
    --auth
```
2. List user info and confirm that credentials for all default SASL/SCRAM mechanisms for MongoDB v5.0.0 are created (`SCRAM-SHA-1`, `SCRAM-SHA-256`).
```bash
mongosh "mongodb://user:password@localhost:27017/admin" --quiet --eval "db.system.users.find()"
[
  {
    _id: 'admin.user',
    userId: UUID("72e25aa8-a058-47a4-b83b-d7c856291511"),
    user: 'user',
    db: 'admin',
    credentials: {
      'SCRAM-SHA-1': {
        iterationCount: 10000,
        salt: <REDACTED>,
        storedKey: <REDACTED>,
        serverKey: <REDACTED>
      },
      'SCRAM-SHA-256': {
        iterationCount: 15000,
        salt: <REDACTED>,
        storedKey: <REDACTED>,
        serverKey: <REDACTED>
      }
    },
    roles: [
      { role: 'dbAdminAnyDatabase', db: 'admin' },
      { role: 'readWriteAnyDatabase', db: 'admin' },
      { role: 'userAdminAnyDatabase', db: 'admin' },
      { role: 'clusterAdmin', db: 'admin' }
    ]
  }
]
```

O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            |  12.4
| Windows          |
