### PR TITLE
Fix missing package name in extras requirements and add missing prereq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ ordereddict>=1.1
 python-dateutil>=2.8.2,<3.0.0
 numpy>=1.23.4
 matplotlib>=3.6.1,<4.0.0
+packaging>=21.3
 pymongo>=4.3.2,<5.0.0
 psutil>=5.9.3,<6.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ try:
     base_extras_requires = ['python-dateutil>=2.8.2,<3.0.0']
     extras_requires = {
         "all": ['numpy>=1.23.4', 'matplotlib>=3.6.1,<4.0.0', 'pymongo>=4.3.2,<5.0.0',
-                '5.9.3,<6.0.0'] + base_extras_requires,
-        "mlaunch": ['pymongo>=4.3.2,<5.0.0', '5.9.3,<6.0.0'] + base_extras_requires,
+                'psutil>=5.9.3,<6.0.0'] + base_extras_requires,
+        "mlaunch": ['pymongo>=4.3.2,<5.0.0', 'psutil>=5.9.3,<6.0.0'] + base_extras_requires,
         "mlogfilter": base_extras_requires.copy(),
         "mloginfo": ['numpy>=1.23.4'] + base_extras_requires,
         "mplotqueries": ['numpy>=1.23.4', 'matplotlib>=3.6.1,<4.0.0'] + base_extras_requires,

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ try:
     base_extras_requires = ['python-dateutil>=2.8.2,<3.0.0']
     extras_requires = {
         "all": ['numpy>=1.23.4', 'matplotlib>=3.6.1,<4.0.0', 'pymongo>=4.3.2,<5.0.0',
-                'psutil>=5.9.3,<6.0.0'] + base_extras_requires,
-        "mlaunch": ['pymongo>=4.3.2,<5.0.0', 'psutil>=5.9.3,<6.0.0'] + base_extras_requires,
+                'psutil>=5.9.3,<6.0.0', 'packaging>=21.3'] + base_extras_requires,
+        "mlaunch": ['pymongo>=4.3.2,<5.0.0', 'psutil>=5.9.3,<6.0.0', 'packaging>=21.3'] + base_extras_requires,
         "mlogfilter": base_extras_requires.copy(),
         "mloginfo": ['numpy>=1.23.4'] + base_extras_requires,
         "mplotqueries": ['numpy>=1.23.4', 'matplotlib>=3.6.1,<4.0.0'] + base_extras_requires,


### PR DESCRIPTION
# Description of changes

* The `psutil` package name was missing in the `setup.py`, causing running `setup.py` to fail.
* The `packaging` module is used by `mlaunch` but was not added to its prereqs.
