### PR TITLE
adjust else block in logevent.py __init__() to fix logevent tests

### DIFF
--- a/mtools/test/test_util_logevent.py
+++ b/mtools/test/test_util_logevent.py
@@ -192,7 +192,7 @@ def test_logevent_actual_sort_parsing():
     le = LogEvent(line_pattern_26_c)
     assert(le.actual_sort) == '{ b: 1.0 }'
 
-@pytest.mark.skip(reason='TODO: update profile parsing')
+# @pytest.mark.skip(reason='TODO: update profile parsing')
 def test_logevent_profile_pattern_parsing():
     le = LogEvent(profile_doc1)
     assert(le.pattern == '{"test": 1}')
@@ -203,7 +203,7 @@ def test_logevent_profile_pattern_parsing():
     le = LogEvent(profile_doc3)
     assert(le.pattern == '{"test": 1}')
 
-@pytest.mark.skip(reason='TODO: update profile parsing')
+# @pytest.mark.skip(reason='TODO: update profile parsing')
 def test_logevent_profile_sort_pattern_parsing():
     le = LogEvent(profile_doc1)
     assert(le.sort_pattern is None)

--- a/mtools/util/logevent.py
+++ b/mtools/util/logevent.py
@@ -84,13 +84,13 @@ class LogEvent(object):
 
                 # Legacy log lines will be parsed lazily
                 self._reset()
-            else:
-                # Assume this is a system.profile document
-                self.from_string = False
-                self.logformat = LogFormat.PROFILE
-                if fulldoc:
-                    self._doc = doc_or_str
-                self._parse_profile_doc(doc_or_str)
+        else:
+            # Assume this is a system.profile document
+            self.from_string = False
+            self.logformat = LogFormat.PROFILE
+            if fulldoc:
+                self._doc = doc_or_str
+            self._parse_profile_doc(doc_or_str)
 
     def _reset(self):
         self._split_tokens_calculated = False


### PR DESCRIPTION
Patch to fix the indentation of the `__init__()` function on `logevent.py` to fix the profile tests