### PR TITLE
Support embeddedcrs

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -296,7 +296,7 @@ class MLaunchTool(BaseCmdLineTool):
                                        'setup (requires --sharded, default=1)'))
         
         init_parser.add_argument('--embeddedcsrs', default=False, action='store_true',
-                                 help=('use embedded CSRS, default=False'))        
+                                 help=('use embedded CSRS (only for MongoDB 8.0.0+), default=False'))        
 
         # As of MongoDB 3.6, all config servers must be CSRS
         init_parser.add_argument('--csrs', default=True, action='store_true',
@@ -672,7 +672,7 @@ class MLaunchTool(BaseCmdLineTool):
             self.args['csrs'] = True
 
         if self.args['embeddedcsrs'] and version.parse(self.current_version) < version.parse("8.0.0"):
-            print("--embeddedcsrs can only be used with 8.0.0+ version")
+            print("--embeddedcsrs can only be used with MongoDB 8.0.0+")
             sys.exit(1)
 
         # construct startup strings
@@ -1757,6 +1757,10 @@ class MLaunchTool(BaseCmdLineTool):
                     # --sharded was a number, name shards shard01, shard02,
                     # ... (only works with replica sets)
                     n_shards = int(args['sharded'][0])
+
+                    if args["embeddedcsrs"]:
+                        n_shards -= 1
+
                     shard_names = ['shard%.2i'
                                    % (i + 1) for i in range(n_shards)]
                 except ValueError:

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -294,6 +294,9 @@ class MLaunchTool(BaseCmdLineTool):
                                  type=int, metavar='NUM',
                                  help=('adds NUM config servers to sharded '
                                        'setup (requires --sharded, default=1)'))
+        
+        init_parser.add_argument('--embeddedcsrs', default=False, action='store_true',
+                                 help=('use embedded CSRS, default=False'))        
 
         # As of MongoDB 3.6, all config servers must be CSRS
         init_parser.add_argument('--csrs', default=True, action='store_true',
@@ -668,6 +671,10 @@ class MLaunchTool(BaseCmdLineTool):
                 version.parse(self.current_version) == version.parse("0.0.0")):
             self.args['csrs'] = True
 
+        if self.args['embeddedcsrs'] and version.parse(self.current_version) < version.parse("8.0.0"):
+            print("--embeddedcsrs can only be used with 8.0.0+ version")
+            sys.exit(1)
+
         # construct startup strings
         self._construct_cmdlines()
 
@@ -721,6 +728,8 @@ class MLaunchTool(BaseCmdLineTool):
                        "an additional '--port <startport>'\n")
             raise SystemExit(errmsg)
 
+
+        
         if self.args['sharded']:
 
             shard_names = self._get_shard_names(self.args)
@@ -737,18 +746,20 @@ class MLaunchTool(BaseCmdLineTool):
                         print('Initiating config server replica set.')
                     members = sorted(self.get_tagged(["config"]))
                     self._initiate_replset(members[0], "configRepl")
-                for shard in shard_names:
-                    # initiate replica set on first member
-                    if self.args['verbose']:
-                        print('Initiating shard replica set %s.' % shard)
-                    members = sorted(self.get_tagged([shard]))
-                    self._initiate_replset(members[0], shard)
+
+                if not (self.args['embeddedcsrs'] and int(self.args['sharded'][0]) == 1):
+                    for shard in shard_names:
+                        # initiate replica set on first member
+                        if self.args['verbose']:
+                            print('Initiating shard replica set %s.' % shard)
+                        members = sorted(self.get_tagged([shard]))
+                        self._initiate_replset(members[0], shard)
 
             # add mongos
             mongos = sorted(self.get_tagged(['mongos', 'down']))
             self._start_on_ports(mongos, wait=True, override_auth=True)
 
-            if first_init:
+            if first_init and not (self.args['embeddedcsrs'] and int(self.args['sharded'][0]) == 1):
                 # add shards
                 mongos = sorted(self.get_tagged(['mongos']))
                 con = self.client('localhost:%i' % mongos[0])
@@ -791,6 +802,12 @@ class MLaunchTool(BaseCmdLineTool):
                                 print('Shard addition failed: ' + res + ' - will retry')
 
                     time.sleep(1)
+            
+            if self.args['embeddedcsrs']:
+                if self.args['verbose']:
+                    print("Configuring embedded config servers")
+                con = self.client('localhost:%i' % mongos[0])
+                con.admin.command({"transitionFromDedicatedConfigServer": 1})
 
         elif self.args['single']:
             # just start node

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -1820,7 +1820,7 @@ class MLaunchTool(BaseCmdLineTool):
                 command_str = re.sub(r'--keyFile \S+', '', command_str)
 
             try:
-                if os.name == 'nt':
+                if os.name == 'nt' or sys.platform == 'darwin':
                     subprocess.check_call(command_str, shell=True)
                     # create sub process on windows doesn't wait for output,
                     # wait a few seconds for mongod instance up
@@ -1830,6 +1830,8 @@ class MLaunchTool(BaseCmdLineTool):
                                             stderr=subprocess.STDOUT)
 
                 binary = command_str.split()[0]
+                if(binary == "nohup"):
+                    binary = command_str.split()[1]
                 if '--configsvr' in command_str:
                     binary = 'config server'
 
@@ -2173,11 +2175,18 @@ class MLaunchTool(BaseCmdLineTool):
                                       rs_param, newdbpath, newlogpath, port,
                                       auth_param, extra))
         else:
-            command_str = ("\"%s\" %s --dbpath \"%s\" --logpath \"%s\" "
-                           "--port %i --fork "
-                           "%s %s" % (os.path.join(path, 'mongod'), rs_param,
-                                      dbpath, logpath, port, auth_param,
-                                      extra))
+            if sys.platform == 'darwin':
+                command_str = ("nohup \"%s\" %s --dbpath \"%s\" --logpath \"%s\" "
+                            "--port %i"
+                            "%s %s >/dev/null &" % (os.path.join(path, 'mongod'), rs_param,
+                                        dbpath, logpath, port, auth_param,
+                                        extra))
+            else:
+                command_str = ("\"%s\" %s --dbpath \"%s\" --logpath \"%s\" "
+                    "--port %i --fork "
+                    "%s %s" % (os.path.join(path, 'mongod'), rs_param,
+                                dbpath, logpath, port, auth_param,
+                                extra))
 
         # store parameters in startup_info
         self.startup_info[str(port)] = command_str
@@ -2208,9 +2217,14 @@ class MLaunchTool(BaseCmdLineTool):
                                        newlogpath, port, configdb,
                                        auth_param, extra))
         else:
-            command_str = ("%s --logpath \"%s\" --port %i --configdb %s %s %s "
-                           "--fork" % (os.path.join(path, 'mongos'), logpath,
-                                       port, configdb, auth_param, extra))
+            if sys.platform == 'darwin':
+                command_str = ("nohup %s --logpath \"%s\" --port %i --configdb %s %s %s >/dev/null &"
+                            % (os.path.join(path, 'mongos'), logpath,
+                                        port, configdb, auth_param, extra))
+            else:
+                command_str = ("%s --logpath \"%s\" --port %i --configdb %s %s %s "
+                            "--fork" % (os.path.join(path, 'mongos'), logpath,
+                                        port, configdb, auth_param, extra))
 
         # store parameters in startup_info
         self.startup_info[str(port)] = command_str

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -290,7 +290,7 @@ class MLaunchTool(BaseCmdLineTool):
                                        'several singles or replica sets. '
                                        'Provide either list of shard names or '
                                        'number of shards.'))
-        init_parser.add_argument('--config', action='store', default=1,
+        init_parser.add_argument('--config', action='store', default=-1,
                                  type=int, metavar='NUM',
                                  help=('adds NUM config servers to sharded '
                                        'setup (requires --sharded, default=1)'))
@@ -663,8 +663,13 @@ class MLaunchTool(BaseCmdLineTool):
             sys.stderr.write('warning: server requires certificates but no'
                              ' --tlsClientCertificateKeyFile provided\n')
         # number of default config servers
-        if self.args['config'] == -1:
-            self.args['config'] = 1
+        if self.args['config'] == -1 and self.args["sharded"]:
+            if self.args['embeddedcsrs']:
+                print("Config members set to: " + str(self.args['nodes']))
+                self.args['config'] = self.args['nodes']
+            else:
+                print("Config members set to: 1")
+                self.args['config'] = 1
 
         # add the 'csrs' parameter as default for MongoDB >= 3.3.0
         if (version.parse(self.current_version) >= version.parse("3.3.0") or
@@ -674,6 +679,11 @@ class MLaunchTool(BaseCmdLineTool):
         if self.args['embeddedcsrs'] and version.parse(self.current_version) < version.parse("8.0.0"):
             print("--embeddedcsrs can only be used with MongoDB 8.0.0+")
             sys.exit(1)
+
+        # Check if embedded is used, if it's the case the number of shards should be decremented by 1
+        if self.args['embeddedcsrs'] and 'sharded' in self.args and self.args['sharded']:
+            if len(self.args['sharded']) == 1:
+                self.args['sharded'][0] = str(int(self.args['sharded'][0]) - 1)
 
         # construct startup strings
         self._construct_cmdlines()
@@ -727,8 +737,6 @@ class MLaunchTool(BaseCmdLineTool):
             errmsg += (" * You can also specify a different port range with "
                        "an additional '--port <startport>'\n")
             raise SystemExit(errmsg)
-
-
         
         if self.args['sharded']:
 
@@ -746,20 +754,18 @@ class MLaunchTool(BaseCmdLineTool):
                         print('Initiating config server replica set.')
                     members = sorted(self.get_tagged(["config"]))
                     self._initiate_replset(members[0], "configRepl")
-
-                if not (self.args['embeddedcsrs'] and int(self.args['sharded'][0]) == 1):
-                    for shard in shard_names:
-                        # initiate replica set on first member
-                        if self.args['verbose']:
-                            print('Initiating shard replica set %s.' % shard)
-                        members = sorted(self.get_tagged([shard]))
-                        self._initiate_replset(members[0], shard)
+                for shard in shard_names:
+                    # initiate replica set on first member
+                    if self.args['verbose']:
+                        print('Initiating shard replica set %s.' % shard)
+                    members = sorted(self.get_tagged([shard]))
+                    self._initiate_replset(members[0], shard)
 
             # add mongos
             mongos = sorted(self.get_tagged(['mongos', 'down']))
             self._start_on_ports(mongos, wait=True, override_auth=True)
 
-            if first_init and not (self.args['embeddedcsrs'] and int(self.args['sharded'][0]) == 1):
+            if first_init:
                 # add shards
                 mongos = sorted(self.get_tagged(['mongos']))
                 con = self.client('localhost:%i' % mongos[0])
@@ -804,10 +810,9 @@ class MLaunchTool(BaseCmdLineTool):
                     time.sleep(1)
             
             if self.args['embeddedcsrs']:
-                if self.args['verbose']:
-                    print("Configuring embedded config servers")
+                print("Configuring embedded config servers")
                 con = self.client('localhost:%i' % mongos[0])
-                con.admin.command({"transitionFromDedicatedConfigServer": 1})
+                con.admin.command({'transitionFromDedicatedConfigServer': 1})
 
         elif self.args['single']:
             # just start node
@@ -1046,12 +1051,26 @@ class MLaunchTool(BaseCmdLineTool):
             print_docs.append(None)
 
         # configs
+        # temporary list used to find the list of running nodes
+        tmp_config_list = []
+        string_config = "config server"
         for node in sorted(self.get_tagged(['config'])):
-            doc = OrderedDict([('process', 'config server'),
+            if self.cluster_running[node]:
+                status = 'running'
+                if self._check_if_embeddedcsrs():
+                    string_config = "config shard"
+            else:
+                status = 'down'
+
+            doc = OrderedDict([('process', string_config),
                               ('port', node),
-                              ('status', 'running'
-                               if self.cluster_running[node] else 'down')])
-            print_docs.append(doc)
+                              ('status', status)])
+            tmp_config_list.append(doc)
+
+        # construct the final list with the right config type
+        for item in tmp_config_list:
+            item['process'] = string_config
+            print_docs.append(item)
 
         if len(self.get_tagged(['config'])) > 0:
             print_docs.append(None)
@@ -1758,9 +1777,6 @@ class MLaunchTool(BaseCmdLineTool):
                     # ... (only works with replica sets)
                     n_shards = int(args['sharded'][0])
 
-                    if args["embeddedcsrs"]:
-                        n_shards -= 1
-
                     shard_names = ['shard%.2i'
                                    % (i + 1) for i in range(n_shards)]
                 except ValueError:
@@ -2206,6 +2222,20 @@ class MLaunchTool(BaseCmdLineTool):
         else:
             with open(keyfile, 'rb') as f:
                 return ''.join(f.readlines())
+
+    def _check_if_embeddedcsrs(self) -> bool:
+        """
+        Returns True if embedded CSRS is used
+        """
+        mongos = sorted(self.get_tagged(['mongos']))
+        con = self.client('localhost:%i' % mongos[0], readPreference="primaryPreferred")
+        try:
+            if con['config']['shards'].find_one({ '_id': 'config' }):
+                return True
+            return False
+        except OperationFailure:
+            print("WARNING: Unable to check if config server is embedded")
+            return False
 
 def main():
     tool = MLaunchTool()


### PR DESCRIPTION
## Description of changes
Support Embedded config servers

Usage:
`
Will start 1 config server/shard + 1 shard 
./mlaunch.py init --sharded=2 --embeddedcsrs --replicaset --node 1

Will start 1 config server/shard
./mlaunch.py init --sharded=1 --embeddedcsrs --replicaset --node 1
`
