### PR TITLE
Add nohup support for MongoDB 8.2+ without --fork flag

### DIFF
--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -2136,7 +2136,16 @@ class MLaunchTool(BaseCmdLineTool):
                                       rs_param, newdbpath, newlogpath, port,
                                       auth_param, extra))
         else:
-            command_str = ("\"%s\" %s --dbpath \"%s\" --logpath \"%s\" "
+            # Check if mongod is running on 8.2 or higher
+            if int(self.current_version.split('.')[0]) >= 9 or (int(self.current_version.split('.')[0]) == 8 and int(self.current_version.split('.')[1]) >= 2):
+                command_str = ("nohup \"%s\" %s --dbpath \"%s\" --logpath \"%s\" "
+                               "--port %i "
+                               "%s %s > /dev/null 2>&1 &" % (os.path.join(path, 'mongod'), rs_param,
+                                                             dbpath, logpath, port, auth_param,
+                                                             extra))
+                pass
+            else:
+                command_str = ("\"%s\" %s --dbpath \"%s\" --logpath \"%s\" "
                            "--port %i --fork "
                            "%s %s" % (os.path.join(path, 'mongod'), rs_param,
                                       dbpath, logpath, port, auth_param,
@@ -2171,9 +2180,15 @@ class MLaunchTool(BaseCmdLineTool):
                                        newlogpath, port, configdb,
                                        auth_param, extra))
         else:
-            command_str = ("%s --logpath \"%s\" --port %i --configdb %s %s %s "
-                           "--fork" % (os.path.join(path, 'mongos'), logpath,
-                                       port, configdb, auth_param, extra))
+            # Check if mongos is running 8.2 or higher
+            if int(self.current_version.split('.')[0]) >= 9 or (int(self.current_version.split('.')[0]) == 8 and int(self.current_version.split('.')[1]) >= 2):
+                command_str = ("nohup %s --logpath \"%s\" --port %i --configdb %s %s %s "
+                               "> /dev/null 2>&1 &" % (os.path.join(path, 'mongos'), logpath,
+                                                       port, configdb, auth_param, extra))
+            else:
+                command_str = ("%s --logpath \"%s\" --port %i --configdb %s %s %s "
+                               "--fork" % (os.path.join(path, 'mongos'), logpath,
+                                           port, configdb, auth_param, extra))
 
         # store parameters in startup_info
         self.startup_info[str(port)] = command_str

--- a/mtools/mlaunch/mlaunch.py
+++ b/mtools/mlaunch/mlaunch.py
@@ -2143,7 +2143,6 @@ class MLaunchTool(BaseCmdLineTool):
                                "%s %s > /dev/null 2>&1 &" % (os.path.join(path, 'mongod'), rs_param,
                                                              dbpath, logpath, port, auth_param,
                                                              extra))
-                pass
             else:
                 command_str = ("\"%s\" %s --dbpath \"%s\" --logpath \"%s\" "
                            "--port %i --fork "


### PR DESCRIPTION
## Description of changes
This change simply swaps the `--fork` flag with `nohup` for versions of mongod and mongos running on 8.2 and newer to avoid the error below.

```
BadValue: Server fork+exec via `--fork` or `processManagement.fork` is incompatible with macOS
```

## Testing
### Single
```
└─[130] <git:(fix/mongodb-8.2-fork 36eb6e3✱✈) > python -m mtools.mlaunch.mlaunch init --single
Detected mongod version: 8.2.1
launching: nohup on port 27017

└─[0] <git:(fix/mongodb-8.2-fork 36eb6e3✱✈) > python -m mtools.mlaunch.mlaunch list --verbose
Detected mongod version: 8.2.1

PROCESS    PORT     STATUS     PID      TAGS

single     27017    running    93928    27017, all, mongod, running, single
```

### Replica Set
```
└─[0] <git:(fix/mongodb-8.2-fork 36eb6e3✱✈) > python -m mtools.mlaunch.mlaunch init --replicaset --nodes 3
Detected mongod version: 8.2.1
launching: nohup on port 27017
launching: nohup on port 27018
launching: nohup on port 27019
replica set 'replset' initialized.

└─[0] <git:(fix/mongodb-8.2-fork 36eb6e3✱✈) > mongosh mongodb://localhost:27017,27018,27019 --quiet --eval "db.version()"
8.2.1

└─[0] <git:(fix/mongodb-8.2-fork 36eb6e3✱✈) > mlaunch list --verbose
Detected mongod version: 8.2.1

PROCESS    PORT     STATUS     PID      TAGS

mongod     27017    running    99672    27017, all, mongod, running
mongod     27018    running    99674    27018, all, mongod, running
mongod     27019    running    99676    27019, all, mongod, running
```

### Sharded cluster
```
└─[0] <git:(fix/mongodb-8.2-fork 36eb6e3✱✈) > python -m mtools.mlaunch.mlaunch init --replicaset --sharded 2 --config 1 --mongos 1
Detected mongod version: 8.2.1
launching: nohup on port 27018
launching: nohup on port 27019
launching: nohup on port 27020
launching: nohup on port 27021
launching: nohup on port 27022
launching: nohup on port 27023
launching: config server on port 27024
replica set 'configRepl' initialized.
replica set 'shard01' initialized.
replica set 'shard02' initialized.
launching: nohup on port 27017
adding shards. can take up to 30 seconds...

└─[1] <git:(fix/mongodb-8.2-fork 36eb6e3✱✈) > mongosh --quiet --eval "db.version()"
8.2.1

└─[0] <git:(fix/mongodb-8.2-fork 36eb6e3✈) > python -m mtools.mlaunch.mlaunch list --verbose
Detected mongod version: 8.2.1

PROCESS          PORT     STATUS     PID      TAGS

mongos           27017    running    28714    27017, all, mongos, running

config server    27024    running    28665    27024, all, config, mongod, running

shard01
    secondary    27020    running    28657    27020, all, mongod, running, secondary, shard01
    mongod       27018    running    28653    27018, all, mongod, running, shard01
    mongod       27019    running    28655    27019, all, mongod, running, shard01

shard02
    mongod       27021    running    28659    27021, all, mongod, running, shard02
    mongod       27022    running    28661    27022, all, mongod, running, shard02
    mongod       27023    running    28663    27023, all, mongod, running, shard02
```

O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | Not tested
| macOS            | Darwin 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:41 PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T6000 arm64
| Windows          | N/A
